### PR TITLE
gulp.src("glob", {read:true, buffer:false})

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 components
 *.orig
 .idea
+out-fixtures

--- a/lib/createInputStream.js
+++ b/lib/createInputStream.js
@@ -5,7 +5,22 @@ var es = require('event-stream'),
 module.exports = function(glob, opt) {
   if (!opt) opt = {};
 
+  var readFileOpt = {
+    buffer: false,
+    read: true
+  };
+  if (opt.hasOwnProperty('buffer')) {
+    readFileOpt.buffer = !!opt.buffer;
+    delete opt.buffer;
+  }
+  if (opt.hasOwnProperty('read')) {
+    readFileOpt.read = !!opt.read;
+    delete opt.read;
+  }
+
   var globStream = gs.create(glob, opt);
-  var stream = globStream.pipe(es.map(readFile));
+  var stream = globStream.pipe(es.map(function (file, cb) {
+    readFile(file, readFileOpt, cb);
+  }));
   return stream;
 };

--- a/lib/readFile.js
+++ b/lib/readFile.js
@@ -1,14 +1,51 @@
 var fs = require('fs'),
   realBase = require('gulp-util').realBase;
 
-module.exports = function (file, cb) {
-  fs.readFile(file.path, function (err, data) {
-    if (err) return cb(err);
-    cb(null, {
+module.exports = function (file, opts, cb) {
+  if (!cb) {
+    cb = opts;
+    opts = {
+      buffer:false,
+      read:true
+    };
+  }
+
+  var doCb = function (err, data, isDirectory) {
+    if (err) {
+      return cb(err);
+    }
+    var newFile = {
       shortened: realBase(file.base, file.path),
       base: file.base,
       path: file.path,
       contents: data
-    });
+    };
+    if (isDirectory) {
+      newFile.isDirectory = true;
+    }
+    cb(null, newFile);
+  };
+
+  fs.stat(file.path, function (err, stat) {
+    if (err) {
+      return cb(err);
+    }
+
+    if (stat.isDirectory()) {
+      // No content for directory, avoid 'Error: EISDIR, read'
+      doCb(null, null, true);
+    } else if (opts.buffer) {
+      // buffer = true, readFileSync
+      var data = fs.readFileSync(file.path);
+      doCb(null, data);
+    } else if (opts.read) {
+      // buffer = false, read = true, readFile (async)
+      fs.readFile(file.path, function (err, data) {
+        doCb(err, data);
+      });
+    } else {
+      // buffer = false, read = false, no content
+      doCb(null, null);
+    }
   });
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "optimist":"0.6.0",
       "gulp-util":"1.0.0",
       "gaze":"0.4.2",
-      "orchestrator": "0.0.5"
+      "orchestrator": "0.0.6"
    },
    "devDependencies":{
       "mocha":"*",

--- a/test/file-utils.js
+++ b/test/file-utils.js
@@ -19,5 +19,33 @@ describe('gulp readFile', function() {
         done();
       });
     });
+    it('should return no content when asked', function(done) {
+      var fname = join(__dirname, "./fixtures/test.coffee");
+      gulp.readFile({path:fname,base:fname}, {read:false}, function(err, struct) {
+        should.not.exist(err);
+        should.exist(struct);
+        should.exist(struct.path);
+        should.not.exist(struct.contents);
+        should.exist(struct.base);
+        struct.path.should.equal(fname);
+        struct.base.should.equal(fname);
+        done();
+      });
+    });
+    it('should return no content for directory', function(done) {
+      var fname = join(__dirname, "./fixtures");
+      gulp.readFile({path:fname,base:fname}, function(err, struct) {
+        should.not.exist(err);
+        should.exist(struct);
+        should.exist(struct.path);
+        should.not.exist(struct.contents);
+        should.exist(struct.isDirectory);
+        struct.isDirectory.should.equal(true);
+        should.exist(struct.base);
+        struct.path.should.equal(fname);
+        struct.base.should.equal(fname);
+        done();
+      });
+    });
   });
 });

--- a/test/out-fixtures/copy/example.txt
+++ b/test/out-fixtures/copy/example.txt
@@ -1,1 +1,0 @@
-this is a test


### PR DESCRIPTION
gulp.src("glob", {read:true, buffer:false}): consumer can choose to buffer:true (read sync) or read:false (don't read file)
