### PR TITLE
Add docs on tasks depending on other async tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,6 @@ gulp.task('default', function(){
 });
 ```
 
-##### Task dependencies
-
-```javascript
-gulp.task('somename', ['array','of','task','names'], function(){
-  // do stuff
-});
-```
-
 ##### Async tasks
 
 With callbacks:
@@ -191,6 +183,17 @@ gulp.task('somename', function(){
   return deferred.promise;
 });
 ```
+
+##### Task dependencies
+
+```javascript
+gulp.task('somename', ['array','of','task','names'], function(){
+  // do stuff
+});
+```
+
+If the dependencies are asynchronous, it is not guaranteed that they will finish before `'somename'` is executed. To ensure they are completely finished, you need to make sure the dependency tasks have asynchronous support through one of the methods outlined above. The most simple method is to return the stream. By returning the stream, Orchestrator is able to listen for the end event and only run `'somename'` once each dependencies' stream end event has been emitted.
+
 
 ### gulp.run(tasks...[, cb])
 


### PR DESCRIPTION
I found myself getting confused when I had a task that depended on
another that was async. After a while I realised why and thought adding
a couple of sentences just to clarify for future users who may come
stuck with the same problem.

I dropped you guys a tweet earlier: https://twitter.com/Jack_Franklin/status/408017546894651392, before some help from Eric cleared things up - I'm not sure if you feel this is a problem many will come across but it had me befuddled for a few moments so I thought a quick 2 sentences in the docs might help others avoid the problem. I don't think it's immediately apparent why returning the stream works as a solution, so I hope this might clarify it.
