### PR TITLE
Allow file contents to be strings

### DIFF
--- a/lib/createOutputStream/writeFile.js
+++ b/lib/createOutputStream/writeFile.js
@@ -21,7 +21,11 @@ module.exports = function (writePath, file, cb) {
     return;
   }
 
-  if (gutil.isBuffer(file.contents)) {
+  var _isString = function(obj){
+    return Object.prototype.toString.call(obj) == '[object String]'
+  };
+
+  if (gutil.isBuffer(file.contents) || _isString(file.contents) ) {
     // write it like normal
     fs.writeFile(writePath, file.contents, function(err){
       if (err) return cb(err);

--- a/test/dest.js
+++ b/test/dest.js
@@ -3,6 +3,7 @@ var should = require('should');
 var join = require('path').join;
 var rimraf = require('rimraf');
 var fs = require('fs');
+var es = require('event-stream');
 
 require('mocha');
 
@@ -14,6 +15,80 @@ describe('gulp output stream', function() {
       should.exist(stream);
       should.exist(stream.on);
       done();
+    });
+
+    it('should be able to write buffered content', function(done){
+      var outpath = join(__dirname, "./out-fixtures");
+      rimraf(outpath, function(err){
+        should.not.exist(err);
+        var instream = gulp.src(join(__dirname, "./fixtures/**/*.txt"));
+        var bufferifyContents = es.through(
+          function(file){
+            file.contents = new Buffer(file.contents);
+            this.emit('data', file);
+          },
+          function(){ this.emit('end'); }
+        );
+        var outstream = gulp.dest(outpath);
+        instream
+          .pipe(bufferifyContents)
+          .pipe(outstream);
+
+        outstream.on('error', done);
+        outstream.on('data', function(file) {
+          // data should be re-emitted right
+          should.exist(file);
+          should.exist(file.path);
+          should.exist(file.contents);
+          join(file.path,'').should.equal(join(__dirname, "./fixtures/copy/example.txt"));
+          String(file.contents).should.equal("this is a test");
+        });
+        outstream.on('end', function() {
+          fs.readFile(join(outpath, "copy", "example.txt"), function(err, contents){
+            should.not.exist(err);
+            should.exist(contents);
+            String(contents).should.equal("this is a test");
+            done();
+          });
+        });
+      });
+    });
+
+    it('should be able to write string content', function(done){
+      var outpath = join(__dirname, "./out-fixtures");
+      rimraf(outpath, function(err){
+        should.not.exist(err);
+        var instream = gulp.src(join(__dirname, "./fixtures/**/*.txt"));
+        var stringifyContents = es.through(
+          function(file){
+            file.contents = new String(file.contents);
+            this.emit('data', file);
+          },
+          function(){ this.emit('end'); }
+        );
+        var outstream = gulp.dest(outpath);
+        instream
+          .pipe(stringifyContents)
+          .pipe(outstream);
+
+        outstream.on('error', done);
+        outstream.on('data', function(file) {
+          // data should be re-emitted right
+          should.exist(file);
+          should.exist(file.path);
+          should.exist(file.contents);
+          join(file.path,'').should.equal(join(__dirname, "./fixtures/copy/example.txt"));
+          String(file.contents).should.equal("this is a test");
+        });
+        outstream.on('end', function() {
+          fs.readFile(join(outpath, "copy", "example.txt"), function(err, contents){
+            should.not.exist(err);
+            should.exist(contents);
+            String(contents).should.equal("this is a test");
+            done();
+          });
+        });
+      });
     });
 
     it('should return a output stream that writes files', function(done) {


### PR DESCRIPTION
Some gulp plugins (eg. [gulp-coffee](https://github.com/wearefractal/gulp-coffee)) replace the file contents with a
transpiled string. This fix writes string contents to disk the same way it would be written if it were a buffer.
