### PR TITLE
Better handling when 'default' task is missing from gulpfile.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,15 @@ Gulp.prototype.taskQueue = Gulp.prototype.seq;
 Gulp.prototype.task = Gulp.prototype.add;
 Gulp.prototype.run = function(){
   var tasks = Array.prototype.slice.call(arguments);
+
+  // check case where 'default' task is not defined
+  if (!this.tasks.default) {
+    gutil.log(gutil.colors.red("Error"), "There is no", 
+      gutil.colors.cyan("'default'"),  "task defined in your 'gulpfile.js'");
+    gutil.log("Please check the documentation for proper gulpfile.js formating.");
+    return;
+  }
+
   
   // impose our opinion of "default" tasks onto orchestrator
   if (!tasks.length) {


### PR DESCRIPTION
### Changing this:

![Original](http://than.pol.as/Sxtl/Screen%20Shot%202013-12-16%20at%209.07.19%20PM.png)
### To this:

![Changed to](http://than.pol.as/Syqj/Screen%20Shot%202013-12-16%20at%209.06.34%20PM.png)

When there is no `default` task defined in the `gulpfile.js` file.
