### PR TITLE
add .coffee to require.extensions by import coffee-script module

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+try{
+  var cs = require('coffee-script');
+} catch(e){}
 
 var path = require('path');
 var fs = require('fs');


### PR DESCRIPTION
so gulpfile.coffee will works if coffee-script is installed.
