### PR TITLE
Update glob-stream version to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp",
   "description": "The streaming build system",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "homepage": "http://github.com/wearefractal/gulp",
   "repository": "git://github.com/wearefractal/gulp.git",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",


### PR DESCRIPTION
Updated glob-stream to version 3.1.0. This version allows users to set the base path for all files. Use case: User wants to copy "lib/**" and "bin/**" to /my/path/lib and /my/path/bin.
