### PR TITLE
Permit gulp.src().pipe(gulp.src()) ?

### DIFF
--- a/test/src.js
+++ b/test/src.js
@@ -2,6 +2,7 @@ var gulp = require('../');
 var should = require('should');
 var join = require('path').join;
 var semver = require('semver');
+var gutil = require('gulp-util');
 
 require('mocha');
 
@@ -171,6 +172,37 @@ describe('gulp input stream', function() {
       });
       stream.on('end', function() {
         a.should.equal(1);
+        done();
+      });
+    });
+
+    it('should repeat piped in file streams', function(done) {
+      var a = 0;
+      var fakeFile = new gutil.File({
+        path: 'foo.txt',
+        content: new Buffer('plop')
+      });
+      var stream = gulp.src(join(__dirname, "./fixtures/test.coffee"));
+      stream.write(fakeFile);
+      stream.on('error', done);
+      stream.on('data', function(file) {
+        ++a;
+        if (1 === a) {
+          should.exist(file);
+          should.exist(file.path);
+          should.exist(file.contents);
+          file.path.should.equal("foo.txt");
+          String(file.contents).should.equal("plop");
+        } else if (2 ===a) {
+          should.exist(file);
+          should.exist(file.path);
+          should.exist(file.contents);
+          join(file.path,'').should.equal(join(__dirname, "./fixtures/test.coffee"));
+          String(file.contents).should.equal("this is a test");
+        }
+      });
+      stream.on('end', function() {
+        a.should.equal(2);
         done();
       });
     });


### PR DESCRIPTION
I'm wondering the interest of doing it ? It has been discussed on IRC but i report it there to get the whole community input. On my side, i don't have opinion on it. I just mind, why not ?

The use case i see is being able to retrieve 2 different folders contents without retrieve all the files contained in their common ancestor.

Another one could be to add some files at some point in the task pipeline.

Below is a test indicating it seems to not work for now, let me know if you wish i should to continue or not.

If so, i'd like to have your input to tell me in which order the files should be passed through (no order, piped in files first or add an option for ordering the files).
