### PR TITLE
Allow .coffee by default

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -19,6 +19,8 @@ var cliPkg = require('../package.json');
 
 var localBaseDir = process.cwd();
 
+findLocalModule('coffee-script',  localBaseDir);
+
 loadRequires(argv.require, localBaseDir);
 
 var gulpFile = getGulpFile(localBaseDir);


### PR DESCRIPTION
Use gulpfile.coffee if coffee-script is found.

I know this is already documented but having to type "gulp task --require coffee-script" instead of "gulp task" each time you want to run a task is a bit much, an extra 24 keystrokes. Please think about it.
