### PR TITLE
Fix typo in testing plugin docs

### DIFF
--- a/docs/writing-a-plugin/testing.md
+++ b/docs/writing-a-plugin/testing.md
@@ -66,7 +66,7 @@ describe('gulp-prefixer', function () {
 
       // create the fake file
       var fakeFile = new gutil.File({
-        contents: new Buffer('abufferwiththiscontent');
+        contents: new Buffer('abufferwiththiscontent')
       });
 
       // Create a prefixer plugin stream


### PR DESCRIPTION
Removed an erroneous `;`
