### PR TITLE
add recipes for specifying a different gulpfile and setting a different base path using plain JS - closes #122

### DIFF
--- a/docs/recipes/specifying-a-different-gulpfile.md
+++ b/docs/recipes/specifying-a-different-gulpfile.md
@@ -1,0 +1,14 @@
+# Specifying a different gulpfile
+
+`gulpfile.js`
+
+```js
+var gulp = require('gulp');
+var path = require('path');
+
+try {
+  require(path.resolve(__dirname, gulp.env.gulpfile));
+} catch (err) {
+  console.error('Unable to load %s', gulp.env.gulpfile);
+}
+```

--- a/docs/recipes/specifying-a-new-base-directory.md
+++ b/docs/recipes/specifying-a-new-base-directory.md
@@ -1,0 +1,13 @@
+# Specifying a new base directory
+
+`gulpfile.js`
+
+```js
+var gulp = require('gulp');
+
+try {
+  process.chdir(gulp.env.base);
+} catch (err) {
+  console.error('Unable to chdir to %s', gulp.env.base);
+}
+```


### PR DESCRIPTION
There is no need for custom logic to specify a custom `gulpfile` or set a custom base.  It can be done with vanilla node.

If `--gulpfile` is still desired, this can be remove when it is implemented, but I don't think it is too much boilerplate.  Especially because you can remove the `try/catch` and just let it error on failure to find the file or directory.
