### PR TITLE
run findup from the cwd

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -135,7 +135,7 @@ function getGulpFile(baseDir) {
   } else {
     extensions = ['.js'];
   }
-  var gulpFile = findup('gulpfile{'+extensions+'}', {nocase: true});
+  var gulpFile = findup('gulpfile{'+extensions+'}', {cwd: cwd, nocase: true});
   return gulpFile;
 }
 


### PR DESCRIPTION
There was a bug with `--cwd` that didn't run `findup` from that `cwd`
