### PR TITLE
task alias convenience method

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -145,6 +145,21 @@ gulp.run('scripts', 'copyfiles', 'builddocs', function(err) {
 
 Use `gulp.run` to run tasks from other tasks. You will probably use this in your default task and to group small tasks into larger tasks.
 
+### gulp.alias(name, tasks...)
+
+#### name
+Type: `String`
+
+Task name to register.
+
+#### tasks
+Type: `String` or `Array`
+
+Tasks to run for that alias. Either an array or a space separated list of task names.
+
+gulp.alias('default', 'lint build publish');
+gulp.alias('default', ['lint', 'build', 'publish']);
+
 ### gulp.watch(glob [, opts], cb)
 
 #### glob

--- a/index.js
+++ b/index.js
@@ -21,6 +21,12 @@ Gulp.prototype.run = function(){
 
   this.start.apply(this, tasks);
 };
+Gulp.prototype.alias = function (alias, names) {
+  var tasks = typeof names === 'string' ? names.split(' ') : names;
+  this.task(alias, function () {
+    this.run.apply(this, tasks);
+  });
+};
 
 Gulp.prototype.src = vfs.src;
 Gulp.prototype.dest = vfs.dest;

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -19,6 +19,40 @@ describe('gulp tasks', function() {
       done();
     });
   });
+  describe('alias()', function() {
+    it('should define an alias using a string', function(done) {
+      var a, fn;
+      a = 0;
+      fn = function() {
+        this.should.equal(gulp);
+        ++a;
+      };
+      gulp.task('task', fn);
+      gulp.alias('test', 'task');
+      should.exist(gulp.tasks.test);
+      gulp.tasks.task.fn.should.equal(fn);
+      gulp.run('test');
+      a.should.equal(1);
+      gulp.reset();
+      done();
+    });
+    it('should define an alias using an array', function(done) {
+      var a, fn;
+      a = 0;
+      fn = function() {
+        this.should.equal(gulp);
+        ++a;
+      };
+      gulp.task('task', fn);
+      gulp.alias('test', ['task']);
+      should.exist(gulp.tasks.test);
+      gulp.tasks.task.fn.should.equal(fn);
+      gulp.run('test');
+      a.should.equal(1);
+      gulp.reset();
+      done();
+    });
+  });
   describe('run()', function() {
     it('should run multiple tasks', function(done) {
       var a, fn, fn2;


### PR DESCRIPTION
It is very common to declare task aliases such as `default` and maybe for each different workflow you have.

Before:

``` js
gulp.task('default', function () {
  gulp.run('jshint', 'build');
});
gulp.task('build', function () {
  gulp.run('js', 'css', 'copy');
});
```

After:

``` js
gulp.alias('default', 'jshint build');
gulp.alias('build', 'js css copy');
```

This is a feature which was always missing in Grunt and which would be nice to add in Gulp. It doesn't add any complexity. I guess it's a nice to have.

Thoughts?
