### PR TITLE
work around not being able to install gulp as a dependency as itself to run gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,30 +1,27 @@
 'use strict';
 
-// TODO: figure out the best way to make gulp a dep of itself
 var gulp = require('./');
+var env = require('gulp-util').env;
+var log = require('gulp-util').log;
 
-var mocha = require('gulp-mocha');
 var jshint = require('gulp-jshint');
 
-var testFiles = 'test/*.js';
-var codeFiles = ['./*.js', './lib/*.js', testFiles];
-
-gulp.task('test', function(){
-  return gulp.src(testFiles)
-    .pipe(mocha({
-      reporter: 'spec'
-    }));
-});
+var codeFiles = ['**/*.js', '!node_modules/**'];
 
 gulp.task('lint', function(){
+  log('Linting Files');
   return gulp.src(codeFiles)
-    .pipe(jshint('.jshintrc'));
+    .pipe(jshint('.jshintrc'))
+    .pipe(jshint.reporter());
 });
 
 gulp.task('watch', function(){
-  gulp.watch(codeFiles, function(){
-    gulp.run('test', 'lint');
-  });
+  log('Watching Files');
+  gulp.watch(codeFiles, ['lint']);
 });
 
-gulp.task('default', ['lint', 'test', 'watch']);
+gulp.task('default', ['lint', 'watch']);
+
+var taskToRun = env.dev ? 'default' : 'lint';
+
+gulp.start(taskToRun);

--- a/package.json
+++ b/package.json
@@ -36,12 +36,11 @@
     "q": "~1.0.0",
     "jshint": "~2.4.1",
     "graceful-fs": "~2.0.1",
-    "gulp-mocha": "~0.4.1",
     "gulp-jshint": "~1.3.4",
     "mkdirp": "~0.3.5"
   },
   "scripts": {
-    "test": "mocha --reporter spec && jshint ./*.js && jshint ./bin/*.js && jshint ./lib/*.js && jshint ./test/*.js",
+    "test": "node gulpfile.js && mocha --reporter spec",
     "coveralls": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "engineStrict": true,


### PR DESCRIPTION
There was no reason to use gulp to run the mocha tests (also, it caused problems with nested orchestrations).
