### PR TITLE
gulp.env deprecated for gulp-util.env or your own CLI parser

### DIFF
--- a/docs/recipes/pass-params-from-cli.md
+++ b/docs/recipes/pass-params-from-cli.md
@@ -6,12 +6,13 @@
 `gulpfile.js`
 
 ```js
-// npm install gulp gulp-if gulp-uglify
+// npm install gulp gulp-util gulp-if gulp-uglify 
 var gulp   = require('gulp');
+var gutil  = require('gulp-util');
 var gulpif = require('gulp-if');
 var uglify = require('gulp-uglify');
 
-var isProduction = gulp.env.type === 'production';
+var isProduction = gutil.env.type === 'production';
 
 gulp.task('scripts', function () {
   return gulp.src('**/*.js')


### PR DESCRIPTION
See: https://github.com/gulpjs/gulp/blob/c6c557b674c6c6fe99d6b8b51823454d1ff83ec8/index.js#L51
