### PR TITLE
Add a hack to allow coffee-script 1.7+

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -102,7 +102,11 @@ function findLocalGulp(gulpFile){
 
 function findLocalModule(modName, baseDir){
   try {
-    return require(resolve.sync(modName, {basedir: baseDir}));
+    var mod = require(resolve.sync(modName, {basedir: baseDir}));
+    if (modName === 'coffee-script' && mod.VERSION >= '1.7.0') {
+      mod.register();
+    }
+    return mod;
   } catch(e) {}
   return;
 }


### PR DESCRIPTION
Coffeescript 1.7+ no longer automatically registers file extensions with Node. To do so, you must call `.register()`:

``` javascript
coffeescript = require('coffee-script')
coffeescript.register()
```

I added a hack-ish solution: just check if the module being required is `"coffee-script"` (and `>= v1.7.0`), and if so, call `register`.

I realize this isn't the cleanest implementation, but thought I would start the issue with some kind of solution at least.
