### PR TITLE
implement the gulp cli using node-liftoff.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var gulp = require('./');
-var env = require('gulp-util').env;
 var log = require('gulp-util').log;
 
 var jshint = require('gulp-jshint');
@@ -21,7 +20,3 @@ gulp.task('watch', function(){
 });
 
 gulp.task('default', ['lint', 'watch']);
-
-var taskToRun = env.dev ? 'default' : 'lint';
-
-gulp.start(taskToRun);

--- a/package.json
+++ b/package.json
@@ -17,14 +17,12 @@
   "dependencies": {
     "gulp-util": "~2.2.0",
     "orchestrator": "~0.3.0",
-    "resolve": "~0.6.1",
-    "findup-sync": "~0.1.2",
     "pretty-hrtime": "~0.2.0",
     "vinyl-fs": "~0.0.2",
     "semver": "~2.2.1",
     "archy": "~0.0.2",
     "deprecated": "~0.0.1",
-    "minimist": "~0.0.5"
+    "liftoff": "~0.8.3"
   },
   "devDependencies": {
     "mocha": "~1.17.0",


### PR DESCRIPTION
this duplicates the functionality of gulp's cli using [node-liftoff](https://github.com/tkellen/node-liftoff), a module that abstracts the annoyances of global/local management in node cli tools.
