### PR TITLE
Skip "Working directory changed" log if not applicable

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -64,9 +64,12 @@ function handleArguments(args) {
 
   var gulpInst = require(args.modulePath);
   logEvents(gulpInst);
-  process.chdir(args.cwd);
-  gutil.log('Working directory changed to', gutil.colors.magenta(args.cwd));
-
+  
+  if (process.cwd() !== args.cwd) {
+    process.chdir(args.cwd);
+    gutil.log('Working directory changed to', gutil.colors.magenta(args.cwd));
+  }
+  
   process.nextTick(function () {
     if (tasksFlag) {
       return logTasks(gulpFile, gulpInst);


### PR DESCRIPTION
```
~/my-app $ gulp foo
[gulp] Using file /Users/callum/code/my-app/gulpfile.js
[gulp] Working directory changed to /Users/callum/code/my-app
```

Currently gulp always says "Working directory changed", even if it didn't change.
