### PR TITLE
Update URLs on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "gulp",
   "description": "The streaming build system",
   "version": "3.5.4",
-  "homepage": "http://github.com/wearefractal/gulp",
-  "repository": "git://github.com/wearefractal/gulp.git",
+  "homepage": "https://github.com/gulpjs/gulp",
+  "repository": "git://github.com/gulpjs/gulp.git",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",
   "main": "./index.js",
   "tags": [
@@ -53,7 +53,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "http://github.com/wearefractal/gulp/raw/master/LICENSE"
+      "url": "https://raw.github.com/gulpjs/gulp/master/LICENSE"
     }
   ]
 }


### PR DESCRIPTION
Even if Github automatically redirects old repository URL to new one, it is prefered that package.json shows the latest information correctly.
