### PR TITLE
Improve watchify recipe.

### DIFF
--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -21,20 +21,17 @@ var watchify = require('watchify')
 var gulp = require('gulp')
 
 var bundler = watchify('./src/index.js')
-var watchFiles = [
-  './src/**/*.js',
-  './src/*.js'
-]
 
-gulp.task('browserify', function() {
+gulp.task('browserify', rebundle)
+gulp.task('watch', ['browserify'], function() {
+  bundler.on('update', rebundle)
+})
+
+function rebundle() {
   return bundler.bundle()
     .pipe(source('bundle.js'))
     .pipe(gulp.dest('./dist'))
-})
-
-gulp.task('watch', ['browserify'], function() {
-  gulp.watch(watchFiles, ['browserify'])
-})
+}
 
 // Optionally, you can apply transforms
 // and other configuration options on the


### PR DESCRIPTION
As @andreypopp pointed out on IRC, this example was doubling up on watchers when it only needed to listen to watchify's "update" event.
