### PR TITLE
support split --cwd / --gulpfile

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -35,20 +35,20 @@ function handleArguments(env) {
 
   if (versionFlag) {
     gutil.log('CLI version', cliPackage.version);
-    if (env.localPackage) {
+    if (env.modulePackage) {
       gutil.log('Local version', env.modulePackage.version);
     }
     process.exit(0);
   }
 
-  if (!env.modulePath) {
-    gutil.log(chalk.red('No local gulp install found in'), chalk.magenta(env.cwd));
-    gutil.log(chalk.red('Try running: npm install gulp'));
+  if (!env.configPath) {
+    gutil.log(chalk.red('No gulpfile found'));
     process.exit(1);
   }
 
-  if (!env.configPath) {
-    gutil.log(chalk.red('No gulpfile found'));
+  if (!env.modulePath) {
+    gutil.log(chalk.red('No local gulp install found in'), chalk.magenta(env.cwd));
+    gutil.log(chalk.red('Try running: npm install gulp'));
     process.exit(1);
   }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "semver": "^2.2.1",
     "archy": "^0.0.2",
     "deprecated": "^0.0.1",
-    "liftoff": "^0.8.7",
+    "liftoff": "^0.9.2",
     "chalk": "^0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Liftoff now supports specifying a different cwd/configfile path.
