### PR TITLE
Set process title to 'gulp'

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -9,6 +9,8 @@ var archy = require('archy');
 var Liftoff = require('liftoff');
 var taskTree = require('../lib/taskTree');
 
+process.title = 'gulp';
+
 var cli = new Liftoff({
   name: 'gulp',
   completions: require('../lib/completion')


### PR DESCRIPTION
Sets the process title so that gulp is easier to find in process lists.
