### PR TITLE
Keep watch running on errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,11 @@ Gulp.prototype.watch = function (glob, opt, fn) {
     opt = null;
   }
 
+  // Orchestrator will throw if no one listens to its 'err' event.
+  if (this.listeners('err').length === 0) {
+    this.on('err', gutil.noop);
+  }
+
   // array of tasks given
   if (Array.isArray(fn)) {
     return vfs.watch(glob, opt, function(){

--- a/test/watch.js
+++ b/test/watch.js
@@ -107,5 +107,34 @@ describe('gulp', function() {
       });
     });
 
+    it('should not throw errors', function (done) {
+      // arrange
+      var tempFile = path.join(outpath, 'watch-task-options.txt');
+
+      fs.writeFile(tempFile, tempFileContent, function () {
+        gulp.task('error', function (done) {
+          done(new Error('Don\'t throw me!'));
+        });
+
+        gulp.watch(tempFile, ['error']);
+
+        // assert
+        function shouldNotThrow(error) {
+          should.not.exist(error);
+        }
+
+        process.on('uncaughtException', shouldNotThrow);
+
+        // clean up
+        setTimeout(function () {
+          process.removeListener('uncaughtException', shouldNotThrow);
+          done();
+        }, writeTimeout * 2);
+
+        // act: change file
+        writeFileWait(tempFile, tempFileContent + ' changed');
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Prevent `watch` from stopping on errors by listening to `err` event, make it works well with all the plugins that emit errors properly (i.e. errors should be emitted by `this.emit('error', error)`).
