### PR TITLE
Recommend `yargs` over `optimist`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -224,7 +224,6 @@ Type: `String`
 The path to the file that triggered the event.
 
 
-[node-optimist]: https://github.com/substack/node-optimist
 [node-glob documentation]: https://github.com/isaacs/node-glob#options
 [node-glob]: https://github.com/isaacs/node-glob
 [glob-stream]: https://github.com/wearefractal/glob-stream

--- a/docs/recipes/pass-params-from-cli.md
+++ b/docs/recipes/pass-params-from-cli.md
@@ -6,8 +6,8 @@
 `gulpfile.js`
 
 ```js
-// npm install gulp optimist gulp-if gulp-uglify
-var args   = require('optimist').argv;
+// npm install gulp yargs gulp-if gulp-uglify
+var args   = require('yargs').argv;
 var gulp   = require('gulp');
 var gulpif = require('gulp-if');
 var uglify = require('gulp-uglify');

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ Gulp.prototype.watch = function (glob, opt, fn) {
 Gulp.prototype.Gulp = Gulp;
 
 // deprecations
-deprecated.field('gulp.env has been deprecated. Use your own CLI parser instead. We recommend using optimist or minimist.', console.log, Gulp.prototype, 'env', gutil.env);
+deprecated.field('gulp.env has been deprecated. Use your own CLI parser instead. We recommend using yargs or minimist.', console.log, Gulp.prototype, 'env', gutil.env);
 Gulp.prototype.run = deprecated.method('gulp.run() has been deprecated. Use task dependencies or gulp.watch task triggering instead.', console.log, Gulp.prototype.run);
 
 var inst = new Gulp();


### PR DESCRIPTION
Substack has deprecated the `optimist` package, recommending the use of
it's successor, `yargs`.
