### PR TITLE
add missing spaces into function declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var paths = {
   images: 'client/img/**/*'
 };
 
-gulp.task('scripts', function () {
+gulp.task('scripts', function() {
   // Minify and copy all JavaScript (except vendor scripts)
   return gulp.src(paths.scripts)
     .pipe(coffee())
@@ -42,7 +42,7 @@ gulp.task('scripts', function () {
 });
 
 // Copy all static images
-gulp.task('images', function () {
+gulp.task('images', function() {
  return gulp.src(paths.images)
     // Pass in options to the task
     .pipe(imagemin({optimizationLevel: 5}))
@@ -50,7 +50,7 @@ gulp.task('images', function () {
 });
 
 // Rerun the task when a file changes
-gulp.task('watch', function () {
+gulp.task('watch', function() {
   gulp.watch(paths.scripts, ['scripts']);
   gulp.watch(paths.images, ['images']);
 });

--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -14,11 +14,11 @@ var cli = new Liftoff({
   completions: require('../lib/completion')
 });
 
-cli.on('require', function (name) {
+cli.on('require', function(name) {
   gutil.log('Requiring external module', chalk.magenta(name));
 });
 
-cli.on('requireFail', function (name) {
+cli.on('requireFail', function(name) {
   gutil.log(chalk.red('Failed to load external module'), chalk.magenta(name));
 });
 
@@ -70,7 +70,7 @@ function handleArguments(env) {
     gutil.log('Working directory changed to', chalk.magenta(env.cwd));
   }
 
-  process.nextTick(function () {
+  process.nextTick(function() {
     if (tasksFlag) {
       return logTasks(gulpFile, gulpInst);
     }
@@ -81,7 +81,7 @@ function handleArguments(env) {
 function logTasks(gulpFile, localGulp) {
   var tree = taskTree(localGulp.tasks);
   tree.label = 'Tasks for ' + chalk.magenta(gulpFile);
-  archy(tree).split('\n').forEach(function (v) {
+  archy(tree).split('\n').forEach(function(v) {
     if (v.trim().length === 0) return;
     gutil.log(v);
   });
@@ -96,22 +96,22 @@ function formatError(e) {
 
 // wire up logging events
 function logEvents(gulpInst) {
-  gulpInst.on('task_start', function (e) {
+  gulpInst.on('task_start', function(e) {
     gutil.log('Starting', "'" + chalk.cyan(e.task) + "'...");
   });
 
-  gulpInst.on('task_stop', function (e) {
+  gulpInst.on('task_stop', function(e) {
     var time = prettyTime(e.hrDuration);
     gutil.log('Finished', "'" + chalk.cyan(e.task) + "'", 'after', chalk.magenta(time));
   });
 
-  gulpInst.on('task_err', function (e) {
+  gulpInst.on('task_err', function(e) {
     var msg = formatError(e);
     var time = prettyTime(e.hrDuration);
     gutil.log("'" + chalk.cyan(e.task) + "'", 'errored after', chalk.magenta(time), chalk.red(msg));
   });
 
-  gulpInst.on('task_not_found', function (err) {
+  gulpInst.on('task_not_found', function(err) {
     gutil.log(chalk.red("Task '" + err.task + "' was not defined in your gulpfile but you tried to run it."));
     gutil.log('Please check the documentation for proper gulpfile formatting.');
     process.exit(1);

--- a/docs/API.md
+++ b/docs/API.md
@@ -59,7 +59,7 @@ The path (folder) to write files to.
 Define a task using [Orchestrator].
 
 ```javascript
-gulp.task('somename', function () {
+gulp.task('somename', function() {
   // Do stuff
 });
 ```
@@ -74,7 +74,7 @@ Type: `Array`
 An array of tasks to be executed and completed before your task will run.
 
 ```javascript
-gulp.task('mytask', ['array', 'of', 'task', 'names'], function () {
+gulp.task('mytask', ['array', 'of', 'task', 'names'], function() {
   // Do stuff
 });
 ```
@@ -93,7 +93,7 @@ Tasks can be made asynchronous if its `fn` does one of the following:
 ##### Accept a callback
 
 ```javascript
-gulp.task('somename', function (cb) {
+gulp.task('somename', function(cb) {
   // Do stuff
   cb(err);
 });
@@ -102,7 +102,7 @@ gulp.task('somename', function (cb) {
 ##### Return a stream
 
 ```javascript
-gulp.task('somename', function () {
+gulp.task('somename', function() {
   var stream = gulp.src('./client/**/*.js')
     .pipe(minify())
     .pipe(gulp.dest('/build'));
@@ -115,11 +115,11 @@ gulp.task('somename', function () {
 ```javascript
 var Q = require('q');
 
-gulp.task('somename', function () {
+gulp.task('somename', function() {
   var deferred = Q.defer();
 
   // Do async stuff
-  setTimeout(function () {
+  setTimeout(function() {
     deferred.resolve();
   }, 1);
 
@@ -146,13 +146,13 @@ So this example would look like this:
 var gulp = require('gulp');
 
 // takes in a callback so the engine knows when it'll be done
-gulp.task('one', function (cb) {
+gulp.task('one', function(cb) {
     // do stuff -- async or otherwise
     cb(err); // if err is not null and not undefined, the run will stop, and note that it failed
 });
 
 // identifies a dependent task must be complete before this one begins
-gulp.task('two', ['one'], function () {
+gulp.task('two', ['one'], function() {
     // task 'one' is done now
 });
 
@@ -183,7 +183,7 @@ Names of task(s) to run when a file changes, added with `gulp.task()`
 
 ```javascript
 var watcher = gulp.watch('js/**/*.js', ['uglify','reload']);
-watcher.on('change', function (event) {
+watcher.on('change', function(event) {
   console.log('File '+event.path+' was '+event.type+', running tasks...');
 });
 ```
@@ -206,7 +206,7 @@ Type: `Function`
 Callback to be called on each change.
 
 ```javascript
-gulp.watch('js/**/*.js', function (event) {
+gulp.watch('js/**/*.js', function(event) {
   console.log('File '+event.path+' was '+event.type+', running tasks...');
 });
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ npm install --save-dev gulp
 ```javascript
 var gulp = require('gulp');
 
-gulp.task('default', function () {
+gulp.task('default', function() {
   // place code for your default task here
 });
 ```

--- a/docs/recipes/combining-streams-to-handle-errors.md
+++ b/docs/recipes/combining-streams-to-handle-errors.md
@@ -14,7 +14,7 @@ var Combine = require('stream-combiner');
 var uglify = require('gulp-uglify');
 var gulp = require('gulp');
 
-gulp.task('test', function () {
+gulp.task('test', function() {
   var combined = Combine(
     gulp.src('bootstrap/js/*.js'),
     uglify(),
@@ -24,7 +24,7 @@ gulp.task('test', function () {
   // any errors in the above streams
   // will get caught by this listener,
   // instead of being thrown:
-  combined.on('error', function (err) {
+  combined.on('error', function(err) {
     console.warn(err.message)
   });
 

--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -20,7 +20,7 @@ var gulp = require('gulp')
 var source = require('vinyl-source-stream')
 var watchify = require('watchify')
 
-gulp.task('watch', function () {
+gulp.task('watch', function() {
   var bundler = watchify('./src/index.js');
 
   // Optionally, you can apply transforms

--- a/docs/recipes/mocha-test-runner-with-gulp.md
+++ b/docs/recipes/mocha-test-runner-with-gulp.md
@@ -6,7 +6,7 @@
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
  
-gulp.task('tests', function () {
+gulp.task('tests', function() {
     return gulp.src(['test/test-*.js'], { read: false })
         .pipe(mocha({
             reporter: 'spec',
@@ -29,13 +29,13 @@ var mocha = require('gulp-mocha');
 var batch = require('gulp-batch');
 var gutil = require('gulp-util');
 
-gulp.task('mocha', function () {
+gulp.task('mocha', function() {
     return gulp.src(['test/*.js'], { read: false })
         .pipe(mocha({ reporter: 'list' }))
         .on('error', gutil.log);
 });
 
-gulp.watch(['lib/**', 'test/**'], batch(function (events, cb) {
+gulp.watch(['lib/**', 'test/**'], batch(function(events, cb) {
     gulp.run('mocha', cb);
 }));
 ```
@@ -50,15 +50,15 @@ var mocha = require('gulp-mocha');
 var watch = require('gulp-watch');
 var gutil = require('gulp-util')
 
-gulp.task('mocha', function () {
+gulp.task('mocha', function() {
     return gulp.src(['test/*.js'], { read: false })
         .pipe(mocha({ reporter: 'list' }))
         .on('error', gutil.log);
 });
 
-gulp.task('watch', function () {
+gulp.task('watch', function() {
     return gulp.src(['lib/**', 'test/**'], { read: false })
-        .pipe(watch(function (events, cb) {
+        .pipe(watch(function(events, cb) {
             gulp.run('mocha', cb);
         }));
 });

--- a/docs/recipes/only-pass-through-changed-files.md
+++ b/docs/recipes/only-pass-through-changed-files.md
@@ -14,7 +14,7 @@ var uglify = require('gulp-uglify');
 var SRC = 'src/*.js';
 var DEST = 'dist';
 
-gulp.task('default', function () {
+gulp.task('default', function() {
 	return gulp.src(SRC)
 		// the `changed` task needs to know the destination directory
 		// upfront to be able to figure out which files changed

--- a/docs/recipes/pass-params-from-cli.md
+++ b/docs/recipes/pass-params-from-cli.md
@@ -14,7 +14,7 @@ var uglify = require('gulp-uglify');
 
 var isProduction = args.type === 'production';
 
-gulp.task('scripts', function () {
+gulp.task('scripts', function() {
   return gulp.src('**/*.js')
     .pipe(gulpif(isProduction, uglify())) // only minify if production
     .pipe(gulp.dest('dist'));

--- a/docs/recipes/rebuild-only-files-that-change.md
+++ b/docs/recipes/rebuild-only-files-that-change.md
@@ -7,7 +7,7 @@ var gulp = require('gulp');
 var sass = require('gulp-sass');
 var watch = require('gulp-watch');
 
-gulp.task('default', function () {
+gulp.task('default', function() {
     return gulp.src('./sass/*.scss')
         .pipe(watch())
         .pipe(sass())

--- a/docs/recipes/running-task-steps-per-folder.md
+++ b/docs/recipes/running-task-steps-per-folder.md
@@ -27,15 +27,15 @@ var scriptsPath = './src/scripts/';
 
 function getFolders(dir) {
     return fs.readdirSync(dir)
-      .filter(function (file) {
+      .filter(function(file) {
         return fs.statSync(path.join(dir, file)).isDirectory();
       });
 }
  
-gulp.task('scripts', function () { 
+gulp.task('scripts', function() { 
    var folders = getFolders(scriptsPath);
    
-   var tasks = folders.map(function (folder) {
+   var tasks = folders.map(function(folder) {
       // concat into foldername.js
       // write to output
       // minify

--- a/docs/recipes/running-tasks-in-series.md
+++ b/docs/recipes/running-tasks-in-series.md
@@ -19,13 +19,13 @@ So this example would look like this:
 var gulp = require('gulp');
 
 // takes in a callback so the engine knows when it'll be done
-gulp.task('one', function (cb) {
+gulp.task('one', function(cb) {
     // do stuff -- async or otherwise
     cb(err); // if err is not null and not undefined, the orchestration will stop, and 'two' will not run
 });
 
 // identifies a dependent task must be complete before this one begins
-gulp.task('two', ['one'], function () {
+gulp.task('two', ['one'], function() {
     // task 'one' is done now
 });
 

--- a/docs/recipes/sharing-streams-with-stream-factories.md
+++ b/docs/recipes/sharing-streams-with-stream-factories.md
@@ -16,7 +16,7 @@ var coffee = require('gulp-coffee');
 var jshint = require('gulp-jshint');
 var stylish = require('jshint-stylish');
 
-gulp.task('bootstrap', function () {
+gulp.task('bootstrap', function() {
   return gulp.src('bootstrap/js/*.js')
     .pipe(jshint())
     .pipe(jshint.reporter(stylish))
@@ -24,7 +24,7 @@ gulp.task('bootstrap', function () {
     .pipe(gulp.dest('public/bootstrap'));
 });
 
-gulp.task('coffee', function () {
+gulp.task('coffee', function() {
   return gulp.src('lib/js/*.coffee')
     .pipe(coffee())
     .pipe(jshint())
@@ -51,13 +51,13 @@ var jsTransform = lazypipe()
   .pipe(jshint.reporter, stylish)
   .pipe(uglify);
 
-gulp.task('bootstrap', function () {
+gulp.task('bootstrap', function() {
   return gulp.src('bootstrap/js/*.js')
     .pipe(jsTransform())
     .pipe(gulp.dest('public/bootstrap'));
 });
 
-gulp.task('coffee', function () {
+gulp.task('coffee', function() {
   return gulp.src('lib/js/*.coffee')
     .pipe(coffee())
     .pipe(jsTransform())

--- a/docs/recipes/using-external-config-file.md
+++ b/docs/recipes/using-external-config-file.md
@@ -41,7 +41,7 @@ function doStuff(cfg) {
     .pipe(gulp.dest(cfg.dest));
 }
 
-gulp.task('dry', function () {
+gulp.task('dry', function() {
   doStuff(config.desktop);
   doStuff(config.mobile);
 });

--- a/docs/recipes/using-multiple-sources-in-one-task.md
+++ b/docs/recipes/using-multiple-sources-in-one-task.md
@@ -6,7 +6,7 @@
 var gulp = require('gulp');
 var es = require('event-stream');
 
-gulp.task('test', function (cb) {
+gulp.task('test', function(cb) {
     return es.concat(
         gulp.src('bootstrap/js/*.js')
             .pipe(gulp.dest('public/bootstrap')),
@@ -25,7 +25,7 @@ var gulp = require('gulp');
 var concat = require('gulp-concat');
 var streamqueue = require('streamqueue');
 
-gulp.task('default', function () {
+gulp.task('default', function() {
     return streamqueue({ objectMode: true },
         gulp.src('foo/*'),
         gulp.src('bar/*')
@@ -36,7 +36,7 @@ gulp.task('default', function () {
 
 // ... or ...
 
-gulp.task('default', function () {
+gulp.task('default', function() {
     var stream = streamqueue({ objectMode: true });
     stream.queue(gulp.src('foo/*'));
     stream.queue(gulp.src('bar/*'));

--- a/docs/writing-a-plugin/dealing-with-streams.md
+++ b/docs/writing-a-plugin/dealing-with-streams.md
@@ -24,7 +24,7 @@ function prefixStream(prefixText) {
   return stream;
 }
 
-// Plugin level function (dealing with files)
+// Plugin level function(dealing with files)
 function gulpPrefixer(prefixText) {
 
   if (!prefixText) {
@@ -33,7 +33,7 @@ function gulpPrefixer(prefixText) {
   prefixText = new Buffer(prefixText); // allocate ahead of time
 
   // Creating a stream through which each file will pass
-  var stream = through.obj(function (file, enc, callback) {
+  var stream = through.obj(function(file, enc, callback) {
     if (file.isNull()) {
       this.push(file); // Do nothing if no contents
       return callback();

--- a/docs/writing-a-plugin/guidelines.md
+++ b/docs/writing-a-plugin/guidelines.md
@@ -59,7 +59,7 @@ function prefixStream(prefixText) {
   return stream;
 }
 
-// Plugin level function (dealing with files)
+// Plugin level function(dealing with files)
 function gulpPrefixer(prefixText) {
 
   if (!prefixText) {
@@ -68,7 +68,7 @@ function gulpPrefixer(prefixText) {
   prefixText = new Buffer(prefixText); // allocate ahead of time
 
   // Creating a stream through which each file will pass
-  var stream = through.obj(function (file, enc, callback) {
+  var stream = through.obj(function(file, enc, callback) {
     if (file.isNull()) {
       this.push(file); // Do nothing if no contents
       return callback();

--- a/docs/writing-a-plugin/testing.md
+++ b/docs/writing-a-plugin/testing.md
@@ -16,10 +16,10 @@ var es = require('event-stream');
 var File = require('vinyl');
 var prefixer = require('../index');
 
-describe('gulp-prefixer', function () {
-  describe('in streaming mode', function () {
+describe('gulp-prefixer', function() {
+  describe('in streaming mode', function() {
 
-    it('should prepend text', function (done) {
+    it('should prepend text', function(done) {
 
       // create the fake file
       var fakeFile = new File({
@@ -33,12 +33,12 @@ describe('gulp-prefixer', function () {
       myPrefixer.write(fakeFile);
 
       // wait for the file to come back out
-      myPrefixer.once('data', function (file) {
+      myPrefixer.once('data', function(file) {
         // make sure it came out the same way it went in
         assert(file.isStream());
 
         // buffer the contents to make sure it got prepended to
-        file.contents.pipe(es.wait(function (err, data) {
+        file.contents.pipe(es.wait(function(err, data) {
           // check the contents
           assert.equal(data, 'prependthistostreamwiththosecontents');
           done();
@@ -59,10 +59,10 @@ var es = require('event-stream');
 var File = require('vinyl');
 var prefixer = require('../index');
 
-describe('gulp-prefixer', function () {
-  describe('in buffer mode', function () {
+describe('gulp-prefixer', function() {
+  describe('in buffer mode', function() {
 
-    it('should prepend text', function (done) {
+    it('should prepend text', function(done) {
 
       // create the fake file
       var fakeFile = new File({
@@ -76,7 +76,7 @@ describe('gulp-prefixer', function () {
       myPrefixer.write(fakeFile);
 
       // wait for the file to come back out
-      myPrefixer.once('data', function (file) {
+      myPrefixer.once('data', function(file) {
         // make sure it came out the same way it went in
         assert(file.isBuffer());
 

--- a/docs/writing-a-plugin/using-buffers.md
+++ b/docs/writing-a-plugin/using-buffers.md
@@ -15,7 +15,7 @@ var PluginError = gutil.PluginError;
 // Consts
 const PLUGIN_NAME = 'gulp-prefixer';
 
-// Plugin level function (dealing with files)
+// Plugin level function(dealing with files)
 function gulpPrefixer(prefixText) {
 
   if (!prefixText) {
@@ -24,7 +24,7 @@ function gulpPrefixer(prefixText) {
   prefixText = new Buffer(prefixText); // allocate ahead of time
 
   // Creating a stream through which each file will pass
-  var stream = through.obj(function (file, enc, callback) {
+  var stream = through.obj(function(file, enc, callback) {
     if (file.isNull()) {
       this.push(file); // Do nothing if no contents
       return callback();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,14 +7,14 @@ var jshint = require('gulp-jshint');
 
 var codeFiles = ['**/*.js', '!node_modules/**'];
 
-gulp.task('lint', function () {
+gulp.task('lint', function() {
   log('Linting Files');
   return gulp.src(codeFiles)
     .pipe(jshint('.jshintrc'))
     .pipe(jshint.reporter());
 });
 
-gulp.task('watch', function () {
+gulp.task('watch', function() {
   log('Watching Files');
   gulp.watch(codeFiles, ['lint']);
 });

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function Gulp() {
 util.inherits(Gulp, Orchestrator);
 
 Gulp.prototype.task = Gulp.prototype.add;
-Gulp.prototype.run = function () {
+Gulp.prototype.run = function() {
   // run() is deprecated as of 3.5 and will be removed in 4.0
   // use task dependencies instead
 
@@ -24,7 +24,7 @@ Gulp.prototype.run = function () {
 
 Gulp.prototype.src = vfs.src;
 Gulp.prototype.dest = vfs.dest;
-Gulp.prototype.watch = function (glob, opt, fn) {
+Gulp.prototype.watch = function(glob, opt, fn) {
   if (!fn) {
     fn = opt;
     opt = null;
@@ -32,7 +32,7 @@ Gulp.prototype.watch = function (glob, opt, fn) {
 
   // array of tasks given
   if (Array.isArray(fn)) {
-    return vfs.watch(glob, opt, function () {
+    return vfs.watch(glob, opt, function() {
       this.start.apply(this, fn);
     }.bind(this));
   }

--- a/lib/completion.js
+++ b/lib/completion.js
@@ -3,7 +3,7 @@
 var fs = require('fs');
 var path = require('path');
 
-module.exports = function (name) {
+module.exports = function(name) {
   if (typeof name !== 'string') throw new Error('Missing completion type');
   var file = path.join(__dirname, '../completion', name);
   try {

--- a/lib/taskTree.js
+++ b/lib/taskTree.js
@@ -1,7 +1,7 @@
 'use strict';
 
-module.exports = function (tasks) {
-  return Object.keys(tasks).reduce(function (prev, task) {
+module.exports = function(tasks) {
+  return Object.keys(tasks).reduce(function(prev, task) {
     prev.nodes.push({
       label: task,
       nodes: tasks[task].dep

--- a/test/dest.js
+++ b/test/dest.js
@@ -10,25 +10,25 @@ require('mocha');
 
 var outpath = join(__dirname, "./out-fixtures");
 
-describe('gulp output stream', function () {
-  describe('dest()', function () {
+describe('gulp output stream', function() {
+  describe('dest()', function() {
     beforeEach(rimraf.bind(null, outpath));
     afterEach(rimraf.bind(null, outpath));
 
-    it('should return a stream', function (done) {
+    it('should return a stream', function(done) {
       var stream = gulp.dest(join(__dirname, "./fixtures/"));
       should.exist(stream);
       should.exist(stream.on);
       done();
     });
 
-    it('should return a output stream that writes files', function (done) {
+    it('should return a output stream that writes files', function(done) {
       var instream = gulp.src(join(__dirname, "./fixtures/**/*.txt"));
       var outstream = gulp.dest(outpath);
       instream.pipe(outstream);
 
       outstream.on('error', done);
-      outstream.on('data', function (file) {
+      outstream.on('data', function(file) {
         // data should be re-emitted right
         should.exist(file);
         should.exist(file.path);
@@ -36,8 +36,8 @@ describe('gulp output stream', function () {
         join(file.path,'').should.equal(join(outpath, "./copy/example.txt"));
         String(file.contents).should.equal("this is a test");
       });
-      outstream.on('end', function () {
-        fs.readFile(join(outpath, "copy", "example.txt"), function (err, contents) {
+      outstream.on('end', function() {
+        fs.readFile(join(outpath, "copy", "example.txt"), function(err, contents) {
           should.not.exist(err);
           should.exist(contents);
           String(contents).should.equal("this is a test");
@@ -46,21 +46,21 @@ describe('gulp output stream', function () {
       });
     });
 
-    it('should return a output stream that does not write non-read files', function (done) {
+    it('should return a output stream that does not write non-read files', function(done) {
       var instream = gulp.src(join(__dirname, "./fixtures/**/*.txt"), {read:false});
       var outstream = gulp.dest(outpath);
       instream.pipe(outstream);
 
       outstream.on('error', done);
-      outstream.on('data', function (file) {
+      outstream.on('data', function(file) {
         // data should be re-emitted right
         should.exist(file);
         should.exist(file.path);
         should.not.exist(file.contents);
         join(file.path,'').should.equal(join(outpath, "./copy/example.txt"));
       });
-      outstream.on('end', function () {
-        fs.readFile(join(outpath, "copy", "example.txt"), function (err, contents) {
+      outstream.on('end', function() {
+        fs.readFile(join(outpath, "copy", "example.txt"), function(err, contents) {
           should.exist(err);
           should.not.exist(contents);
           done();
@@ -68,20 +68,20 @@ describe('gulp output stream', function () {
       });
     });
 
-    it('should return a output stream that writes streaming files', function (done) {
+    it('should return a output stream that writes streaming files', function(done) {
       var instream = gulp.src(join(__dirname, "./fixtures/**/*.txt"), {buffer:false});
       var outstream = instream.pipe(gulp.dest(outpath));
 
       outstream.on('error', done);
-      outstream.on('data', function (file) {
+      outstream.on('data', function(file) {
         // data should be re-emitted right
         should.exist(file);
         should.exist(file.path);
         should.exist(file.contents);
         join(file.path,'').should.equal(join(outpath, "./copy/example.txt"));
       });
-      outstream.on('end', function () {
-        fs.readFile(join(outpath, "copy", "example.txt"), function (err, contents) {
+      outstream.on('end', function() {
+        fs.readFile(join(outpath, "copy", "example.txt"), function(err, contents) {
           should.not.exist(err);
           should.exist(contents);
           String(contents).should.equal("this is a test");
@@ -90,19 +90,19 @@ describe('gulp output stream', function () {
       });
     });
 
-    it('should return a output stream that writes streaming files into new directories', function (done) {
+    it('should return a output stream that writes streaming files into new directories', function(done) {
       testWriteDir({}, done);
     });
 
-    it('should return a output stream that writes streaming files into new directories (buffer: false)', function (done) {
+    it('should return a output stream that writes streaming files into new directories (buffer: false)', function(done) {
       testWriteDir({buffer: false}, done);
     });
 
-    it('should return a output stream that writes streaming files into new directories (read: false)', function (done) {
+    it('should return a output stream that writes streaming files into new directories (read: false)', function(done) {
       testWriteDir({read: false}, done);
     });
 
-    it('should return a output stream that writes streaming files into new directories (read: false, buffer: false)', function (done) {
+    it('should return a output stream that writes streaming files into new directories (read: false, buffer: false)', function(done) {
       testWriteDir({buffer: false, read: false}, done);
     });
 
@@ -111,14 +111,14 @@ describe('gulp output stream', function () {
       var outstream = instream.pipe(gulp.dest(outpath));
 
       outstream.on('error', done);
-      outstream.on('data', function (file) {
+      outstream.on('data', function(file) {
         // data should be re-emitted right
         should.exist(file);
         should.exist(file.path);
         join(file.path,'').should.equal(join(outpath, "./stuff"));
       });
-      outstream.on('end', function () {
-        fs.exists(join(outpath, "stuff"), function (exists) {
+      outstream.on('end', function() {
+        fs.exists(join(outpath, "stuff"), function(exists) {
           /* stinks that ok is an expression instead of a function call */
           /* jshint expr: true */
           should(exists).be.ok;

--- a/test/src.js
+++ b/test/src.js
@@ -6,30 +6,30 @@ var join = require('path').join;
 
 require('mocha');
 
-describe('gulp input stream', function () {
-  describe('src()', function () {
-    it('should return a stream', function (done) {
+describe('gulp input stream', function() {
+  describe('src()', function() {
+    it('should return a stream', function(done) {
       var stream = gulp.src(join(__dirname, "./fixtures/*.coffee"));
       should.exist(stream);
       should.exist(stream.on);
       done();
     });
-    it('should return a input stream from a flat glob', function (done) {
+    it('should return a input stream from a flat glob', function(done) {
       var stream = gulp.src(join(__dirname, "./fixtures/*.coffee"));
       stream.on('error', done);
-      stream.on('data', function (file) {
+      stream.on('data', function(file) {
         should.exist(file);
         should.exist(file.path);
         should.exist(file.contents);
         join(file.path,'').should.equal(join(__dirname, "./fixtures/test.coffee"));
         String(file.contents).should.equal("this is a test");
       });
-      stream.on('end', function () {
+      stream.on('end', function() {
         done();
       });
     });
 
-    it('should return a input stream for multiple globs', function (done) {
+    it('should return a input stream for multiple globs', function(done) {
       var globArray = [
         join(__dirname, "./fixtures/stuff/run.dmc"),
         join(__dirname, "./fixtures/stuff/test.dmc")
@@ -38,12 +38,12 @@ describe('gulp input stream', function () {
 
       var files = [];
       stream.on('error', done);
-      stream.on('data', function (file) {
+      stream.on('data', function(file) {
         should.exist(file);
         should.exist(file.path);
         files.push(file);
       });
-      stream.on('end', function () {
+      stream.on('end', function() {
         files.length.should.equal(2);
         files[0].path.should.equal(globArray[0]);
         files[1].path.should.equal(globArray[1]);
@@ -51,7 +51,7 @@ describe('gulp input stream', function () {
       });
     });
 
-    it('should return a input stream for multiple globs, with negation', function (done) {
+    it('should return a input stream for multiple globs, with negation', function(done) {
       var expectedPath = join(__dirname, "./fixtures/stuff/run.dmc");
       var globArray = [
         join(__dirname, "./fixtures/stuff/*.dmc"),
@@ -61,19 +61,19 @@ describe('gulp input stream', function () {
 
       var files = [];
       stream.on('error', done);
-      stream.on('data', function (file) {
+      stream.on('data', function(file) {
         should.exist(file);
         should.exist(file.path);
         files.push(file);
       });
-      stream.on('end', function () {
+      stream.on('end', function() {
         files.length.should.equal(1);
         files[0].path.should.equal(expectedPath);
         done();
       });
     });
 
-    it('should return a input stream for multiple globs, with negation', function (done) {
+    it('should return a input stream for multiple globs, with negation', function(done) {
       var expectedPath = join(__dirname, "./fixtures/stuff/run.dmc");
       var globArray = [
         join(__dirname, "./fixtures/stuff/run.dmc"),
@@ -83,81 +83,81 @@ describe('gulp input stream', function () {
 
       var files = [];
       stream.on('error', done);
-      stream.on('data', function (file) {
+      stream.on('data', function(file) {
         should.exist(file);
         should.exist(file.path);
         files.push(file);
       });
-      stream.on('end', function () {
+      stream.on('end', function() {
         files.length.should.equal(1);
         files[0].path.should.equal(expectedPath);
         done();
       });
     });
 
-    it('should return a input stream with no contents when read is false', function (done) {
+    it('should return a input stream with no contents when read is false', function(done) {
       var stream = gulp.src(join(__dirname, "./fixtures/*.coffee"), {read: false});
       stream.on('error', done);
-      stream.on('data', function (file) {
+      stream.on('data', function(file) {
         should.exist(file);
         should.exist(file.path);
         should.not.exist(file.contents);
         join(file.path,'').should.equal(join(__dirname, "./fixtures/test.coffee"));
       });
-      stream.on('end', function () {
+      stream.on('end', function() {
         done();
       });
     });
-    it('should return a input stream with contents as stream when buffer is false', function (done) {
+    it('should return a input stream with contents as stream when buffer is false', function(done) {
       var stream = gulp.src(join(__dirname, "./fixtures/*.coffee"), {buffer: false});
       stream.on('error', done);
-      stream.on('data', function (file) {
+      stream.on('data', function(file) {
         should.exist(file);
         should.exist(file.path);
         should.exist(file.contents);
         var buf = "";
-        file.contents.on('data', function (d) {
+        file.contents.on('data', function(d) {
           buf += d;
         });
-        file.contents.on('end', function () {
+        file.contents.on('end', function() {
           buf.should.equal("this is a test");
           done();
         });
         join(file.path,'').should.equal(join(__dirname, "./fixtures/test.coffee"));
       });
     });
-    it('should return a input stream from a deep glob', function (done) {
+    it('should return a input stream from a deep glob', function(done) {
       var stream = gulp.src(join(__dirname, "./fixtures/**/*.jade"));
       stream.on('error', done);
-      stream.on('data', function (file) {
+      stream.on('data', function(file) {
         should.exist(file);
         should.exist(file.path);
         should.exist(file.contents);
         join(file.path,'').should.equal(join(__dirname, "./fixtures/test/run.jade"));
         String(file.contents).should.equal("test template");
       });
-      stream.on('end', function () {
+      stream.on('end', function() {
         done();
       });
     });
-    it('should return a input stream from a deeper glob', function (done) {
+    it('should return a input stream from a deeper glob', function(done) {
       var stream = gulp.src(join(__dirname, "./fixtures/**/*.dmc"));
       var a = 0;
       stream.on('error', done);
-      stream.on('data', function () {
+      stream.on('data', function() {
         ++a;
       });
-      stream.on('end', function () {
+      stream.on('end', function() {
         a.should.equal(2);
         done();
       });
     });
 
-    it('should return a file stream from a flat path', function (done) {
+    it('should return a file stream from a flat path', function(done) {
       var a = 0;
       var stream = gulp.src(join(__dirname, "./fixtures/test.coffee"));
       stream.on('error', done);
-      stream.on('data', function (file) {
+      stream.on('data', function(file) {
         ++a;
         should.exist(file);
         should.exist(file.path);
@@ -165,7 +165,7 @@ describe('gulp input stream', function () {
         join(file.path,'').should.equal(join(__dirname, "./fixtures/test.coffee"));
         String(file.contents).should.equal("this is a test");
       });
-      stream.on('end', function () {
+      stream.on('end', function() {
         a.should.equal(1);
         done();
       });

--- a/test/taskTree.js
+++ b/test/taskTree.js
@@ -5,8 +5,8 @@ var should = require('should');
 
 require('mocha');
 
-describe('taskTree()', function () {
-  it('should form a tree properly', function (done) {
+describe('taskTree()', function() {
+  it('should form a tree properly', function(done) {
     should.exist(taskTree); // lol shutup jshint
 
     var tasks = {

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -5,11 +5,11 @@ var Q = require('q');
 var should = require('should');
 require('mocha');
 
-describe('gulp tasks', function () {
-  describe('task()', function () {
-    it('should define a task', function (done) {
+describe('gulp tasks', function() {
+  describe('task()', function() {
+    it('should define a task', function(done) {
       var fn;
-      fn = function () {};
+      fn = function() {};
       gulp.task('test', fn);
       should.exist(gulp.tasks.test);
       gulp.tasks.test.fn.should.equal(fn);
@@ -17,15 +17,15 @@ describe('gulp tasks', function () {
       done();
     });
   });
-  describe('run()', function () {
-    it('should run multiple tasks', function (done) {
+  describe('run()', function() {
+    it('should run multiple tasks', function(done) {
       var a, fn, fn2;
       a = 0;
-      fn = function () {
+      fn = function() {
         this.should.equal(gulp);
         ++a;
       };
-      fn2 = function () {
+      fn2 = function() {
         this.should.equal(gulp);
         ++a;
       };
@@ -36,14 +36,14 @@ describe('gulp tasks', function () {
       gulp.reset();
       done();
     });
-    it('should run all tasks when call run() multiple times', function (done) {
+    it('should run all tasks when call run() multiple times', function(done) {
       var a, fn, fn2;
       a = 0;
-      fn = function () {
+      fn = function() {
         this.should.equal(gulp);
         ++a;
       };
-      fn2 = function () {
+      fn2 = function() {
         this.should.equal(gulp);
         ++a;
       };
@@ -55,20 +55,20 @@ describe('gulp tasks', function () {
       gulp.reset();
       done();
     });
-    it('should run all async promise tasks', function (done) {
+    it('should run all async promise tasks', function(done) {
       var a, fn, fn2;
       a = 0;
-      fn = function () {
+      fn = function() {
         var deferred = Q.defer();
-        setTimeout(function () {
+        setTimeout(function() {
           ++a;
           deferred.resolve();
         },1);
         return deferred.promise;
       };
-      fn2 = function () {
+      fn2 = function() {
         var deferred = Q.defer();
-        setTimeout(function () {
+        setTimeout(function() {
           ++a;
           deferred.resolve();
         },1);
@@ -77,7 +77,7 @@ describe('gulp tasks', function () {
       gulp.task('test', fn);
       gulp.task('test2', fn2);
       gulp.run('test');
-      gulp.run('test2', function () {
+      gulp.run('test2', function() {
         gulp.isRunning.should.equal(false);
         a.should.equal(2);
         gulp.reset();
@@ -85,17 +85,17 @@ describe('gulp tasks', function () {
       });
       gulp.isRunning.should.equal(true);
     });
-    it('should run all async callback tasks', function (done) {
+    it('should run all async callback tasks', function(done) {
       var a, fn, fn2;
       a = 0;
-      fn = function (cb) {
-        setTimeout(function () {
+      fn = function(cb) {
+        setTimeout(function() {
           ++a;
           cb(null);
         },1);
       };
-      fn2 = function (cb) {
-        setTimeout(function () {
+      fn2 = function(cb) {
+        setTimeout(function() {
           ++a;
           cb(null);
         },1);
@@ -103,7 +103,7 @@ describe('gulp tasks', function () {
       gulp.task('test', fn);
       gulp.task('test2', fn2);
       gulp.run('test');
-      gulp.run('test2', function () {
+      gulp.run('test2', function() {
         gulp.isRunning.should.equal(false);
         a.should.equal(2);
         gulp.reset();
@@ -111,8 +111,8 @@ describe('gulp tasks', function () {
       });
       gulp.isRunning.should.equal(true);
     });
-    it('should emit task_not_found and throw an error when task is not defined', function (done) {
-      gulp.on('task_not_found', function (err) {
+    it('should emit task_not_found and throw an error when task is not defined', function(done) {
+      gulp.on('task_not_found', function(err) {
         should.exist(err);
         should.exist(err.task);
         err.task.should.equal('test');
@@ -125,10 +125,10 @@ describe('gulp tasks', function () {
         should.exist(err);
       }
     });
-    it('should run task scoped to gulp', function (done) {
+    it('should run task scoped to gulp', function(done) {
       var a, fn;
       a = 0;
-      fn = function () {
+      fn = function() {
         this.should.equal(gulp);
         ++a;
       };
@@ -139,10 +139,10 @@ describe('gulp tasks', function () {
       gulp.reset();
       done();
     });
-    it('should run default task scoped to gulp', function (done) {
+    it('should run default task scoped to gulp', function(done) {
       var a, fn;
       a = 0;
-      fn = function () {
+      fn = function() {
         this.should.equal(gulp);
         ++a;
       };

--- a/test/watch.js
+++ b/test/watch.js
@@ -11,8 +11,8 @@ require('mocha');
 
 var outpath = path.join(__dirname, "./out-fixtures");
 
-describe('gulp', function () {
-  describe('watch()', function () {
+describe('gulp', function() {
+  describe('watch()', function() {
     beforeEach(rimraf.bind(null, outpath));
     beforeEach(mkdirp.bind(null, outpath));
     afterEach(rimraf.bind(null, outpath));
@@ -20,20 +20,20 @@ describe('gulp', function () {
     var tempFileContent = 'A test generated this file and it is safe to delete';
 
     var writeTimeout = 125; // Wait for it to get to the filesystem
-    var writeFileWait = function (name, content, cb) {
-      if (!cb) cb = function () {};
-      setTimeout(function () {
+    var writeFileWait = function(name, content, cb) {
+      if (!cb) cb = function() {};
+      setTimeout(function() {
         fs.writeFile(name, content, cb);
       }, writeTimeout);
     };
-    it('should call the function when file changes: no options', function (done) {
+    it('should call the function when file changes: no options', function(done) {
 
       // arrange
       var tempFile = path.join(outpath, 'watch-func.txt');
-      fs.writeFile(tempFile, tempFileContent, function () {
+      fs.writeFile(tempFile, tempFileContent, function() {
 
         // assert: it works if it calls done
-        var watcher = gulp.watch(tempFile, function (evt) {
+        var watcher = gulp.watch(tempFile, function(evt) {
           should.exist(evt);
           should.exist(evt.path);
           should.exist(evt.type);
@@ -48,13 +48,13 @@ describe('gulp', function () {
       });
     });
 
-    it('should call the function when file changes: w/ options', function (done) {
+    it('should call the function when file changes: w/ options', function(done) {
       // arrange
       var tempFile = path.join(outpath, 'watch-func-options.txt');
-      fs.writeFile(tempFile, tempFileContent, function () {
+      fs.writeFile(tempFile, tempFileContent, function() {
 
         // assert: it works if it calls done
-        var watcher = gulp.watch(tempFile, {debounceDelay:5}, function (evt) {
+        var watcher = gulp.watch(tempFile, {debounceDelay:5}, function(evt) {
           should.exist(evt);
           should.exist(evt.path);
           should.exist(evt.type);
@@ -69,7 +69,7 @@ describe('gulp', function () {
       });
     });
 
-    it('should run many tasks: w/ options', function (done) {
+    it('should run many tasks: w/ options', function(done) {
       // arrange
       var tempFile = path.join(outpath, 'watch-task-options.txt');
       var task1 = 'task1';
@@ -78,20 +78,20 @@ describe('gulp', function () {
       var a = 0;
       var timeout = writeTimeout * 2.5;
 
-      fs.writeFile(tempFile, tempFileContent, function () {
+      fs.writeFile(tempFile, tempFileContent, function() {
 
-        gulp.task(task1, function () {
+        gulp.task(task1, function() {
           a++;
         });
-        gulp.task(task2, function () {
+        gulp.task(task2, function() {
           a += 10;
         });
-        gulp.task(task3, function () {
+        gulp.task(task3, function() {
           throw new Error("task3 called!");
         });
 
         // assert
-        setTimeout(function () {
+        setTimeout(function() {
           a.should.equal(11); // task1 and task2
 
           gulp.reset();


### PR DESCRIPTION
There is no consistency in putting space before parentheses in anonymous function declaration.
For example in [README.MD](https://github.com/gulpjs/gulp/blob/master/README.md#sample-gulpfile) Sample gulpfile:
At line 23 there is no space before ()

``` javascript
gulp.task('images', function() {
```

At line 31 there is a space

``` javascript
gulp.task('watch', function () {
```

I've added missing spaces according to [code conventions](http://javascript.crockford.com/code.html)
There were also some missing spaces between ')' and '{'. I've added them too.
