### PR TITLE
Include completion files for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "files": [
     "index.js",
     "lib",
-    "bin"
+    "bin",
+    "completion"
   ],
   "bin": {
     "gulp": "./bin/gulp.js"


### PR DESCRIPTION
Currently running `gulp --completion=[zsh|bash]` will not work because the completion files are not being included in npm. By including the completion directory in the files array in package.json they will be installed by npm.

``` sh
Specified gulp shell auto-completion rules for '[zsh|bash]' not found
```

---

**CHANGES:**
- Adds completion dir to package.json files

---

Let me know if this PR needs anything else
