### PR TITLE
Actualize mocha recipe

### DIFF
--- a/docs/recipes/mocha-test-runner-with-gulp.md
+++ b/docs/recipes/mocha-test-runner-with-gulp.md
@@ -6,7 +6,7 @@
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
  
-gulp.task('tests', function() {
+gulp.task('default', function() {
     return gulp.src(['test/test-*.js'], { read: false })
         .pipe(mocha({
             reporter: 'spec',
@@ -19,14 +19,11 @@ gulp.task('tests', function() {
 
 ### Running mocha tests when files change
 
-With bundled `gulp.watch` and [`gulp-batch`](https://github.com/floatdrop/gulp-batch) (see readme of gulp-batch for reasons):
-
 ```js
-// npm install gulp gulp-watch gulp-mocha gulp-batch
+// npm install gulp gulp-mocha
  
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
-var batch = require('gulp-batch');
 var gutil = require('gulp-util');
 
 gulp.task('mocha', function() {
@@ -34,36 +31,7 @@ gulp.task('mocha', function() {
         .pipe(mocha({ reporter: 'list' }))
         .on('error', gutil.log);
 });
-
-gulp.watch(['lib/**', 'test/**'], batch(function(events, cb) {
-    gulp.run('mocha', cb);
-}));
-```
-
-With [`gulp-watch`](https://github.com/floatdrop/gulp-watch) plugin:
-
-```js
-// npm i gulp gulp-watch gulp-mocha
-
-var gulp = require('gulp');
-var mocha = require('gulp-mocha');
-var watch = require('gulp-watch');
-var gutil = require('gulp-util')
-
-gulp.task('mocha', function() {
-    return gulp.src(['test/*.js'], { read: false })
-        .pipe(mocha({ reporter: 'list' }))
-        .on('error', gutil.log);
+gulp.task('watch-mocha', function() {
+    gulp.watch(['lib/**', 'test/**'], ['mocha']);
 });
-
-gulp.task('watch', function() {
-    return gulp.src(['lib/**', 'test/**'], { read: false })
-        .pipe(watch(function(events, cb) {
-            gulp.run('mocha', cb);
-        }));
-});
-
-gulp.task('default', ['mocha', 'watch']);
-
-// run `gulp watch` or just `gulp` for watching and rerunning tests
 ```


### PR DESCRIPTION
- Removed deprecated run usage
- Replaced `gulp-watch` with `gulp.watch`
