### PR TITLE
Another strategy for incremental builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ We recommend these plugins:
 
 - [gulp-changed](https://github.com/sindresorhus/gulp-changed)
 - [gulp-cached](https://github.com/wearefractal/gulp-cached)
+- [gulp-newer](https://github.com/tschaub/gulp-newer)
 
 ## Want to contribute?
 


### PR DESCRIPTION
While the `gulp-changed` and `gulp-cached` plugins work great with 1:1 src:dest file mapping, they should not be used for n:1 src:dest mapping.  With plugins like `gulp-concat`, `css-sprite`, etc. that generate a single output file given many input files, you want to compare the modification time of the output file to the modification file of each input file (and use all if any are newer).

The [`gulp-newer` plugin](https://github.com/tschaub/gulp-newer) works with both 1:1 and n:1 src:dest mapping by comparing `mtime`.
