### PR TITLE
Task description support via forked orchestrator

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,4 +48,18 @@ deprecated.field('gulp.env has been deprecated. Use your own CLI parser instead.
 Gulp.prototype.run = deprecated.method('gulp.run() has been deprecated. Use task dependencies or gulp.watch task triggering instead.', console.log, Gulp.prototype.run);
 
 var inst = new Gulp();
+
+// Register default help task for listing available tasks
+inst.task('help', function() {
+    console.log('\nAvailable tasks:');
+    for (var task in inst.tasks) {
+        if (!inst.tasks.hasOwnProperty(task)) continue;
+        var task = inst.tasks[task],
+            output = ' - ' + task.name;
+        if (task.desc) output += ' — ' + task.desc;
+        console.log(output);
+    }
+    console.log('\n');
+});
+
 module.exports = inst;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "gulp-util": "^2.2.0",
-    "orchestrator": "^0.3.0",
+    "orchestrator": "https://github.com/evindor/orchestrator/tarball/db79144320450447e4f2dcb5bfed2d73f30a3a5e",
     "pretty-hrtime": "^0.2.0",
     "vinyl-fs": "^0.1.0",
     "semver": "^2.2.1",


### PR DESCRIPTION
I've made very simple and straightforward support for tasks listing and description. With [this pull request](https://github.com/orchestrator/orchestrator/pull/40) to orchestrator it's possible to pass a string as a last argument to `gulp.task`:

``` javascript
gulp.task('build', function() {...}, 'Build my project');
```

This PR adds a `help` task by default, so running `gulp help` will produce the following output if `help` task is not overridden in gulpfile:

``` shell
$ gulp help
[gulp] Using file ...
[gulp] Working directory changed to ...
[gulp] Running 'help'...

Available tasks:
 - help
 - build - Build my project

[gulp] Finished 'help' in 254 μs
```

This PR is only to start a discussion, i'll update docs and tests if we agree on this approach.
