### PR TITLE
fix(watch): preserve options parameter if no callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ Gulp.prototype.run = function() {
 Gulp.prototype.src = vfs.src;
 Gulp.prototype.dest = vfs.dest;
 Gulp.prototype.watch = function(glob, opt, fn) {
-  if (!fn) {
+  if (typeof opt === 'function') {
     fn = opt;
     opt = null;
   }

--- a/test/watch.js
+++ b/test/watch.js
@@ -69,6 +69,31 @@ describe('gulp', function() {
       });
     });
 
+    it('should not drop options when no callback specified', function(done) {
+      // arrange
+      var tempFile = path.join(outpath, 'watch-func-nodrop-options.txt');
+      // by passing a cwd option, ensure options are not lost to gaze
+      var relFile = '../watch-func-nodrop-options.txt';
+      var cwd = outpath + '/subdir';
+      fs.writeFile(tempFile, tempFileContent, function() {
+
+        // assert: it works if it calls done
+        var watcher = gulp.watch(relFile, {debounceDelay: 5, cwd: cwd})
+            .on('change', function(evt) {
+              should.exist(evt);
+              should.exist(evt.path);
+              should.exist(evt.type);
+              evt.type.should.equal('changed');
+              evt.path.should.equal(path.resolve(tempFile));
+              watcher.end();
+              done();
+            });
+
+        // act: change file
+        writeFileWait(tempFile, tempFileContent + ' changed');
+      });
+    });
+
     it('should run many tasks: w/ options', function(done) {
       // arrange
       var tempFile = path.join(outpath, 'watch-task-options.txt');


### PR DESCRIPTION
Only if the second parameter is a function will the options object be overwritten to null.

This logic is consistent with glob-watcher, such that options can be passed in cases where
a callback function is not supplied.
