### PR TITLE
add gulp-remember to incremental build readme, add related recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ We recommend these plugins:
 - [gulp-changed](https://github.com/sindresorhus/gulp-changed)
 - [gulp-cached](https://github.com/wearefractal/gulp-cached)
 - [gulp-newer](https://github.com/tschaub/gulp-newer)
+- [gulp-remember](https://github.com/ahaurw01/gulp-remember)
 
 ## Want to contribute?
 

--- a/docs/recipes/incremental-builds-with-concatenate.md
+++ b/docs/recipes/incremental-builds-with-concatenate.md
@@ -1,0 +1,38 @@
+# Incremental rebuilding, including operating on full file sets
+
+The trouble with incremental rebuilds is you often want to operate on _all_ processed files, not just single files. For example, you may want to lint and module-wrap just the file(s) that have changed, then concatenate it with all other linted and module-wrapped files. This is difficult without the use of temp files.
+
+Use [gulp-cached](https://github.com/wearefractal/gulp-cached) and [gulp-remember](https://github.com/ahaurw01/gulp-remember) to achieve this goal.
+
+```javascript
+var gulp = require('gulp'),
+    header = require('gulp-header'),
+    footer = require('gulp-footer'),
+    concat = require('gulp-concat'),
+    jshint = require('gulp-jshint'),
+    cache = require('gulp-cached'),
+    remember = require('gulp-remember');
+
+var scriptsGlob = 'src/**/*.js';
+
+gulp.task('scripts', function () {
+  return gulp.src(scriptsGlob)
+      .pipe(cache('scripts')) // only pass through changed files
+      .pipe(jshint()) // do special things to the changed files...
+      .pipe(header('(function () {')) // e.g. jshinting ^^^
+      .pipe(footer('})();')) // and some kind of module wrapping
+      .pipe(remember('scripts')) // add back all files to the stream
+      .pipe(concat('app.js')) // do things that require all files
+      .pipe(gulp.dest('public/'))
+});
+
+gulp.task('watch', function () {
+  var watcher = gulp.watch(scriptsGlob, ['scripts']); // watch the same files in our scripts task
+  watcher.on('change', function (event) {
+    if (event.type === 'deleted') { // if a file is deleted, forget about it
+      delete cache.caches['scripts'][event.path]; // gulp-cached remove api
+      remember.forget('scripts', event.path); // gulp-remember remove api
+    }
+  });
+});
+```


### PR DESCRIPTION
I have added gulp-remember to the "incremental builds" section of the main README.
I also included a new recipe using gulp-remember and gulp-cached.
