### PR TITLE
Make an explicit pointer to the base option

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -21,7 +21,7 @@ Type: `Object`
 
 Options to pass to [node-glob] through [glob-stream].
 
-gulp adds two additional options in addition to the [options supported by node-glob][node-glob documentation]:
+gulp adds two additional options in addition to the [options supported by node-glob][node-glob documentation] and [glob-stream]:
 
 #### options.buffer
 Type: `Boolean`


### PR DESCRIPTION
And the other glob-stream options for `gulp.src`.
