### PR TITLE
[JSHint] Use "mocha" option instead of specifying globals explicitly

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,10 +3,5 @@
   "undef": true,
   "unused": true,
   "node": true,
-  "globals": {
-    "describe": true,
-    "it": true,
-    "beforeEach": true,
-    "afterEach": true
-  }
+  "mocha": true
 }

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "should": "^3.1.0",
     "rimraf": "^2.2.5",
     "q": "^1.0.0",
-    "jshint": "^2.4.1",
+    "jshint": "^2.5.0",
     "graceful-fs": "^2.0.1",
-    "gulp-jshint": "^1.4.0",
+    "gulp-jshint": "^1.5.3",
     "mkdirp": "^0.3.5"
   },
   "scripts": {


### PR DESCRIPTION
From v2.5.0, JSHint supports the predefined functions of [Mocha](http://visionmedia.github.io/mocha/) with [`mocha` option](https://github.com/jshint/jshint/blob/20e2bee28242fa627e3a98087dda8713850941a9/src/jshint.js#L144).
See jshint/jshint#1597 for details.
