### PR TITLE
Added simple `built with gulp.js` badge using `shields.io` badge service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-# gulp [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coveralls Status][coveralls-image]][coveralls-url] [![Dependency Status][daviddm-image]][daviddm-url]
+# gulp [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coveralls Status][coveralls-image]][coveralls-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Built with gulp.js][built-with-image]](built-with-url)
 > The streaming build system
 
 ## Like what we do?
@@ -85,3 +85,6 @@ Anyone can help make this project better - check out the [Contributing guide](/C
 [depstat-image]: https://david-dm.org/gulpjs/gulp.svg
 [daviddm-url]: https://david-dm.org/gulpjs/gulp
 [daviddm-image]: https://david-dm.org/gulpjs/gulp.svg?theme=shields.io
+[built-with-image]: http://img.shields.io/badge/built%20with-gulp.js-red.svg
+[built-with-url]: http://gulpjs.com
+


### PR DESCRIPTION
I added into `README.md` header this badge:  [![Built with gulp.js](http://img.shields.io/badge/built%20with-gulp.js-red.svg)](http://gulpjs.com)
This should partially sort the https://github.com/gulpjs/gulp/issues/403
