### PR TITLE
Renaming "cache" to "cached" for clarity

### DIFF
--- a/docs/recipes/incremental-builds-with-concatenate.md
+++ b/docs/recipes/incremental-builds-with-concatenate.md
@@ -10,14 +10,14 @@ var gulp = require('gulp'),
     footer = require('gulp-footer'),
     concat = require('gulp-concat'),
     jshint = require('gulp-jshint'),
-    cache = require('gulp-cached'),
+    cached = require('gulp-cached'),
     remember = require('gulp-remember');
 
 var scriptsGlob = 'src/**/*.js';
 
 gulp.task('scripts', function () {
   return gulp.src(scriptsGlob)
-      .pipe(cache('scripts')) // only pass through changed files
+      .pipe(cached('scripts')) // only pass through changed files
       .pipe(jshint()) // do special things to the changed files...
       .pipe(header('(function () {')) // e.g. jshinting ^^^
       .pipe(footer('})();')) // and some kind of module wrapping


### PR DESCRIPTION
It is misleading to call this `cache` as it is loading the `grunt-cached` plugin.  All of the other variable names accurately represent the module that's being loaded.  Additionally, there is a `grunt-cache` plugin.  If I were to assume that people get things right most of the time, I'd try to first write my code to load `grunt-cache` because that variable is right twice and I would guess that the typo was just in the module name.
