### PR TITLE
only use js variants from interpret

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -13,7 +13,7 @@ var taskTree = require('../lib/taskTree');
 var cli = new Liftoff({
   name: 'gulp',
   completions: require('../lib/completion'),
-  extensions: require('interpret').extensions
+  extensions: require('interpret').jsVariants
 });
 
 cli.on('require', function(name) {


### PR DESCRIPTION
Forgot to switch this&mdash;I added a filtered property on [node-interpret](/tkellen/node-interpret) to limit the extensions to actual js variants (no need to scan for .csv/.ini/etc).
