### PR TITLE
Update github raw url

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://raw.github.com/gulpjs/gulp/master/LICENSE"
+      "url": "https://raw.githubusercontent.com/gulpjs/gulp/master/LICENSE"
     }
   ]
 }


### PR DESCRIPTION
raw.github.com has moved to raw.githubusercontent.com
