### PR TITLE
Fix jshint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "mkdirp": "^0.5.0"
   },
   "scripts": {
-    "test": "jshint && mocha --reporter spec",
+    "test": "jshint --exclude node_modules . && mocha --reporter spec",
     "coveralls": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "engineStrict": true,


### PR DESCRIPTION
Hi!

I think `jshint` without arguments do nothing and it should be `jshint --exclude node_modules .`.

Thanks,
