### PR TITLE
docs: add missing 'new' operator for thrown error

### DIFF
--- a/docs/writing-a-plugin/dealing-with-streams.md
+++ b/docs/writing-a-plugin/dealing-with-streams.md
@@ -28,7 +28,7 @@ function prefixStream(prefixText) {
 function gulpPrefixer(prefixText) {
 
   if (!prefixText) {
-    throw PluginError(PLUGIN_NAME, "Missing prefix text!");
+    throw new PluginError(PLUGIN_NAME, "Missing prefix text!");
   }
   prefixText = new Buffer(prefixText); // allocate ahead of time
 


### PR DESCRIPTION
Just a quick typo fix for the dealing-with-streams docs.
