### PR TITLE
Simplify/clarify logic in writing-a-plugin docs

### DIFF
--- a/docs/writing-a-plugin/dealing-with-streams.md
+++ b/docs/writing-a-plugin/dealing-with-streams.md
@@ -35,27 +35,26 @@ function gulpPrefixer(prefixText) {
   // Creating a stream through which each file will pass
   var stream = through.obj(function(file, enc, callback) {
     if (file.isNull()) {
-      this.push(file); // Do nothing if no contents
-      return callback();
+      // Do nothing if no contents
     }
 
-    if (file.isBuffer()) {
+    else if (file.isBuffer()) {
       this.emit('error', new PluginError(PLUGIN_NAME, 'Buffers not supported!'));
-      return callback();
     }
 
-    if (file.isStream()) {
+    else if (file.isStream()) {
       // define the streamer that will transform the content
       var streamer = prefixStream(prefixText);
       // catch errors from the streamer and emit a gulp plugin error
       streamer.on('error', this.emit.bind(this, 'error'));
       // start the transformation
       file.contents = file.contents.pipe(streamer);
-      // make sure the file goes through the next gulp plugin
-      this.push(file);
-      // tell the stream engine that we are done with this file
-      return callback();
     }
+
+    // make sure the file goes through the next gulp plugin
+    this.push(file);
+    // tell the stream engine that we are done with this file
+    callback();
   });
 
   // returning the file stream

--- a/docs/writing-a-plugin/using-buffers.md
+++ b/docs/writing-a-plugin/using-buffers.md
@@ -26,20 +26,21 @@ function gulpPrefixer(prefixText) {
   // Creating a stream through which each file will pass
   var stream = through.obj(function(file, enc, callback) {
     if (file.isNull()) {
-      this.push(file); // Do nothing if no contents
-      return callback();
+      // Do nothing if no contents
     }
 
-    if (file.isBuffer()) {
+    else if (file.isBuffer()) {
       file.contents = Buffer.concat([prefixText, file.contents]);
-      this.push(file);
-      return callback();
     }
 
-    if (file.isStream()) {
+    else if (file.isStream()) {
       this.emit('error', new PluginError(PLUGIN_NAME, 'Streams are not supported!'));
-      return callback();
     }
+
+    // make sure the file goes through the next gulp plugin
+    this.push(file);
+    // tell the stream engine that we are done with this file
+    callback();
   });
 
   // returning the file stream


### PR DESCRIPTION
Continuing the discussion from https://github.com/gulpjs/gulp/issues/325 to discuss the merits of using else-if statements to simplify and clarify intent, as well as DRY it up.

This PR aims to:
- Simplify/DRY-up code where multiple `this.push(file)` and `return callback();` statements were before.
- Clarify intent, running `callback();` without a return statement; though, still not sure if that was even the original intent.
