### PR TITLE
Export the directory where user invoke gulp to gulpfile.js

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -83,6 +83,7 @@ function handleArguments(env) {
 
   // chdir before requiring gulpfile to make sure
   // we let them chdir as needed
+  var cwd=process.cwd(); 
   if (process.cwd() !== env.cwd) {
     process.chdir(env.cwd);
     if (shouldLog) {
@@ -101,6 +102,7 @@ function handleArguments(env) {
   }
 
   var gulpInst = require(env.modulePath);
+  gulpInst.cwd = cwd; // the directory where user invoke gulp
   logEvents(gulpInst);
 
   process.nextTick(function () {


### PR DESCRIPTION
since 1.2-2.4 (11/12/13)
"chdir to gulpfile directory before loading it"
in gulpfile.js, gulp.cwd stores the directory where user invoke gulp.
this is useful when user working directory has no gulpfile.js and don't want to use --cwd=. 
