### PR TITLE
README.md: Change order of 'default' task dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ gulp.task('watch', function() {
 });
 
 // The default task (called when you run `gulp` from cli)
-gulp.task('default', ['scripts', 'images', 'watch']);
+gulp.task('default', ['watch', 'scripts', 'images']);
 
 ```
 


### PR DESCRIPTION
With proper error handling, this keeps `gulp.watch` running, even when the build steps fail.

See also https://github.com/felixrabe/gulp-setup for my own setup that includes error handling.
(MIT license, clean git history. Go check it out.)
