### PR TITLE
README.md: Use gulp-clean instead of rimraf

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,13 @@ var paths = {
   images: 'client/img/**/*'
 };
 
-// Not all tasks need to use streams,
-// But as you wanna build files after clean old files, you should use gulp-clean, 
+// Not all tasks need to use streams
 // A gulpfile is just another node program and you can use all packages available on npm
 
 gulp.task('clean', function () {
-	return gulp.src('build/', {read: false})
-		.pipe(clean());
+  return gulp.src('build/', {read: false})
+    .pipe(clean());
 });
-
 
 gulp.task('scripts', ['clean'], function() {
   // Minify and copy all JavaScript (except vendor scripts)
@@ -55,7 +53,7 @@ gulp.task('scripts', ['clean'], function() {
 
 // Copy all static images
 gulp.task('images', ['clean'], function() {
- return gulp.src(paths.images)
+  return gulp.src(paths.images)
     // Pass in options to the task
     .pipe(imagemin({optimizationLevel: 5}))
     .pipe(gulp.dest('build/img'));
@@ -77,7 +75,7 @@ gulp.task('default', ['scripts', 'images', 'watch']);
 We recommend these plugins:
 
 - [gulp-changed](https://github.com/sindresorhus/gulp-changed) - only pass through changed files
-- [gulp-cached](https://github.com/wearefractal/gulp-cached) - in-memory file cache, not for operation on sets of files 
+- [gulp-cached](https://github.com/wearefractal/gulp-cached) - in-memory file cache, not for operation on sets of files
 - [gulp-remember](https://github.com/ahaurw01/gulp-remember) - pairs nicely with gulp-cached
 - [gulp-newer](https://github.com/tschaub/gulp-newer) - pass through newer source files only, supports many:1 source:dest
 


### PR DESCRIPTION
This just adds a cleanup commit to @soulteary's contribution in #527.
