### PR TITLE
Add usage with -h|--help flag

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -70,7 +70,7 @@ function handleArguments(env) {
     console.log('Help:     https://github.com/gulpjs/gulp/tree/master/docs');
     console.log('Homepage: http://gulpjs.com/');
 
-      process.exit(0);
+    process.exit(0);
   }
 
   if (!env.modulePath) {


### PR DESCRIPTION
As advised by the [GNU coding standard](http://www.gnu.org/prep/standards/standards.html#g_t_002d_002dhelp), add some usage with `-h|--help` flag.

It got me crazy to have to go the website documentation to just remember the option to specify a custom `gulpfile.js`

![screen shot 2014-06-13 at 14 26 50](https://cloud.githubusercontent.com/assets/345495/3269862/44101af4-f2f6-11e3-8895-d813228e46dc.png)
