### PR TITLE
fixes #531

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "pretty-hrtime": "^0.2.0",
     "semver": "^2.2.1",
     "tildify": "^0.2.0",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^0.3.0",
+    "gaze": "0.5.1"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",


### PR DESCRIPTION
Gulp uses a package called [vinyl-fs](https://github.com/wearefractal/vinyl-fs), which relies on a package called [glob-watcher](https://github.com/wearefractal/glob-watcher), which relies on a package called [gaze](https://github.com/shama/gaze). Versions of gaze later than 0.5.1 cause the problems described in #531. 

glob-watcher is compatible with gaze v0.5.1. If we set gulp to require gaze 0.5.1, glob-watcher will use this version.
