### PR TITLE
use `del` instead of `rimraf` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var concat = require('gulp-concat');
 var uglify = require('gulp-uglify');
 var imagemin = require('gulp-imagemin');
 
-var rimraf = require('rimraf');
+var del = require('del');
 
 var paths = {
   scripts: ['client/js/**/*.coffee', '!client/external/**/*.coffee'],
@@ -36,8 +36,9 @@ var paths = {
 
 // Not all tasks need to use streams
 // A gulpfile is just another node program and you can use all packages available on npm
-gulp.task('clean', function(cb){
-  rimraf('build/', cb);
+gulp.task('clean', function(cb) {
+  // You can use multiple globbing patterns as you would with `gulp.src`
+  del(['build'], cb);
 });
 
 gulp.task('scripts', ['clean'], function() {
@@ -73,7 +74,7 @@ gulp.task('default', ['watch', 'scripts', 'images']);
 We recommend these plugins:
 
 - [gulp-changed](https://github.com/sindresorhus/gulp-changed) - only pass through changed files
-- [gulp-cached](https://github.com/wearefractal/gulp-cached) - in-memory file cache, not for operation on sets of files 
+- [gulp-cached](https://github.com/wearefractal/gulp-cached) - in-memory file cache, not for operation on sets of files
 - [gulp-remember](https://github.com/ahaurw01/gulp-remember) - pairs nicely with gulp-cached
 - [gulp-newer](https://github.com/tschaub/gulp-newer) - pass through newer source files only, supports many:1 source:dest
 

--- a/docs/recipes/running-tasks-in-series.md
+++ b/docs/recipes/running-tasks-in-series.md
@@ -33,14 +33,14 @@ gulp.task('default', ['one', 'two']);
 // alternatively: gulp.task('default', ['two']);
 ```
 
-Another Example, which returns the stream instead of using a callback:  
+Another Example, which returns the stream instead of using a callback:
 
 ```javascript
 var gulp = require('gulp');
-var rimraf = require('rimraf'); //rm -rf 
+var del = require('del'); // rm -rf
 
 gulp.task('clean', function(cb) {
-    rimraf('./output', cb);
+    del(['output'], cb);
 });
 
 gulp.task('templates', ['clean'], function() {
@@ -61,9 +61,9 @@ gulp.task('styles', ['clean'], function() {
 
 gulp.task('build', ['templates', 'styles']);
     // templates and styles will be processed in parallel.
-    // clean will be guaranteed to complete before either start.  
-    // clean will not be run twice, even though it is called as a dependency twice.  
-    
+    // clean will be guaranteed to complete before either start.
+    // clean will not be run twice, even though it is called as a dependency twice.
+
 gulp.task('default', ['build']);
 ```
 

--- a/docs/writing-a-plugin/guidelines.md
+++ b/docs/writing-a-plugin/guidelines.md
@@ -5,7 +5,7 @@
 [Writing a Plugin](README.md) > Guidelines
 
 1. Your plugin should not do something that can be done easily with an existing node module
-  - For example: deleting a folder does not need to be a gulp plugin. Use a module like `rimraf` within a task instead.
+  - For example: deleting a folder does not need to be a gulp plugin. Use a module like [del](https://github.com/sindresorhus/del) within a task instead.
   - Wrapping every possible thing just for the sake of wrapping it will pollute the ecosystem with low quality plugins that don't make sense within the gulp paradigm.
   - gulp plugins are for file-based operations! If you find yourself shoehorning a complex process into streams just make a normal node module instead.
   - A good example of a gulp plugin would be something like gulp-coffee. The coffee-script module does not work with Vinyl out of the box, so we wrap it to add this functionality and abstract away pain points to make it work well within gulp.
@@ -33,7 +33,7 @@
   - If file.contents is a Stream and you don't support that just emit an error
     - Do not buffer a stream to shoehorn your plugin to work with streams. This will cause horrible things to happen.
 1. Do not pass the `file` object downstream until you are done with it
-1. Use [`file.clone()`](https://github.com/wearefractal/vinyl#clone) when cloning a file or creating a new one based on a file. 
+1. Use [`file.clone()`](https://github.com/wearefractal/vinyl#clone) when cloning a file or creating a new one based on a file.
 1. Use modules from our [recommended modules page](recommended-modules.md) to make your life easier
 1. Do NOT require `gulp` as a dependency or peerDependency in your plugin
   - Using gulp to test or automate your plugin workflow is totally cool, just make sure you put it as a devDependency


### PR DESCRIPTION
It supports multiple globbing patterns, so more closely aligns with `gulp.src`.
