### PR TITLE
Only output version if no tasks were specified

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -65,7 +65,7 @@ cli.launch({
 
 // the actual logic
 function handleArguments(env) {
-  if (versionFlag) {
+  if (versionFlag && tasks.length === 0) {
     gutil.log('CLI version', cliPackage.version);
     if (env.modulePackage) {
       gutil.log('Local version', env.modulePackage.version);


### PR DESCRIPTION
This is less "greedy" and allows tasks to make use of the `--version` argument.
