### PR TITLE
Add new recipe for making streams from memory contents

### DIFF
--- a/docs/recipes/make-stream-from-memory-contents.md
+++ b/docs/recipes/make-stream-from-memory-contents.md
@@ -82,19 +82,19 @@ gulp.task('load-versions', function(){
 gulp.task('write-versions', function(){
 
   //  we store all the different version file names in an array
-  var availableVersions = Object.keys(memory.versions),
-      //  we make an array to store all the stream promises
-      streams = [];
+  var availableVersions = Object.keys(memory.versions);
+  //  we make an array to store all the stream promises
+  var streams = [];
 
   availableVersions
   .forEach(function(v){
 
         //  make a new stream with fake file name
-    var stream = source('final.' + v ),
-        //  we load the data from the concatenated libs
-        fileContents = memory['libs.concat.js'] +
-          //  we add the version's data
-          '\n' + memory.versions[v];
+    var stream = source('final.' + v );
+    //  we load the data from the concatenated libs
+    var fileContents = memory['libs.concat.js'] +
+        //  we add the version's data
+        '\n' + memory.versions[v];
 
     streams.push(stream);
 


### PR DESCRIPTION
Submitted a recipe on how to make streams with contents stored in variables.

I have a the example repo here : https://github.com/AntouanK/gulp-stream-test
Only problem I have with this approach is that task `write-versions` exits ok, but at the time it exits, the files are not written. ( add a console.log in [line 77](https://github.com/AntouanK/gulp-stream-test/blob/master/gulpfile.js#L77) where I resolve the promise and you'll see that it's printed after the task ends )

``` bash
541 stream-test (master)$ rm -rf output/ && gulp
[09:57:20] Using gulpfile ~/CODE/stream-test/gulpfile.js
[09:57:20] Starting 'default'...
[09:57:20] Starting 'load-lib-files'...
[09:57:20] Starting 'load-versions'...
[09:57:20] Finished 'load-versions' after 7 ms
[09:57:20] Finished 'load-lib-files' after 16 ms
[09:57:20] Starting 'write-versions'...
[09:57:20] Finished 'write-versions' after 3.98 ms
[09:57:20] Finished 'default' after 21 ms
file written
file written
```
