### PR TITLE
Add pipe condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,20 +67,20 @@ Upgrade: gulp pipe condition
 /*************************************************************/
 (function(gulp) {
   var src = gulp.src;
-  gulp.src = function(){
-    var res = src.apply(gulp, arguments);
-    (function(res){
-      var args = arguments;
+  gulp.src = function(globs, options){
+    var res = src.apply(gulp, [globs, options]);
+    var injector = function(res){
       var pipe = res.pipe;
-      res.pipe = function(cond){
-        if(cond === null){
+      res.pipe = function(fn){
+        if(fn === null){
           return res;
         }
-        res = pipe.apply(res, arguments);
-        args.callee(res);
+        res = pipe.apply(res, [fn]);
+        injector(res);
         return res;
       };
-    }(res));
+    };
+    injector(res);
     return res;
   };
 }(inst));


### PR DESCRIPTION
Let's say I have a `less` task and I want to add `sourcemaps` depending on `environment`. 
## This is the original `less` task with no environment support:

```
gulp.task('less', function() {
  gulp.src('./dev/src/**/*.less')
    .pipe(sourcemaps.init())
    .pipe(less())
    .pipe(sourcemaps.write())
    .pipe(gulp.dest('./.tmp'));
});
```
## This is the common solution:

```
gulp.task('less', function() {
  var res = gulp.src('./dev/src/**/*.less');
  if (env.DEBUG === 'yes') {
    res = res.pipe(sourcemaps.init());
  }
  res = res.pipe(less());
  if (env.DEBUG === 'yes') {
    res = res.pipe(sourcemaps.write());
  }
  res = res.pipe(gulp.dest('./.tmp'));
});
```
## This is my proposed solution, more elegant (I think):

```
gulp.task('less', function() {
  gulp.src('./dev/src/**/*.less')
    .pipe(env.DEBUG === 'yes' ? sourcemaps.init() : null)
    .pipe(less())
    .pipe(env.DEBUG === 'yes' ? sourcemaps.write() : null)
    .pipe(gulp.dest('./.tmp'));
});
```
## Overall idea:

If you add `pipe` like this:

```
gulp.task('less', function() {
  gulp.src('./dev/src/**/*.less')
    .pipe(null)
    .pipe(less())
    .pipe(null)
    .pipe(gulp.dest('./.tmp'));
});
```

Then it will execute like this:

```
gulp.task('less', function() {
  gulp.src('./dev/src/**/*.less')
    .pipe(less())
    .pipe(gulp.dest('./.tmp'));
});
```
