### PR TITLE
update URL to the search plugins site

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -45,5 +45,5 @@ Yes, come chat with us in #gulpjs on [Freenode].
 [Writing a gulp plugin]: writing-a-plugin/README.md
 [gulp introduction slideshow]: http://slid.es/contra/gulp
 [Freenode]: http://freenode.net/
-[search-gulp-plugins]: http://gratimax.github.io/search-gulp-plugins/
+[search-gulp-plugins]: http://gulpjs.com/plugins/
 [npm plugin search]: https://npmjs.org/browse/keyword/gulpplugin


### PR DESCRIPTION
http://gulpjs.com/plugins/ probably be an "official"
search plugins website as it filters out black-listed ones.

Ex.: http://gulpjs.com/plugins/ shows 602 plugins vs. > 800 plugins on http://gratimax.net/search-gulp-plugins/

Not sure which site is the "proper" one, but it would be good to have an "official" pointer in gulp FAQ
