### PR TITLE
Adds proper LICENSE file header according to MIT site

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2014 Fractal <contact@wearefractal.com>
 
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
While reviewing licenses for a project, it seems to me that a header line is missing from the LICENSE file defining that it is in fact MIT (Ref. http://opensource.org/licenses/MIT), or am I missing something here?

This PR fixes this by adding the MIT header to the LICENSE file.
