### PR TITLE
Fix the gulp.watch example in the "Server with live-reloading and CSS injection" recipe

### DIFF
--- a/docs/recipes/server-with-livereload-and-css-injection.md
+++ b/docs/recipes/server-with-livereload-and-css-injection.md
@@ -34,7 +34,7 @@ gulp.task('serve', function() {
     }
   });
 
-  gulp.watch(['*.html', 'styles/**/*.css', 'scripts/**/*.js'], reload);
+  gulp.watch(['*.html', 'styles/**/*.css', 'scripts/**/*.js'], {cwd: 'app'}, reload);
 });
 
 ```


### PR DESCRIPTION
gulp.watch is relative to `process.cwd()`. We thus need to indicate the `app` directory as the base.
