### PR TITLE
Create missing `gulp.dest` parameter docs.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -37,7 +37,7 @@ Default: `true`
 
 Setting this to `false` will return `file.contents` as null and not read the file at all.
 
-### gulp.dest(path)
+### gulp.dest(path[, options])
 
 Can be piped to and it will write files. Re-emits all data passed to it so you can pipe to multiple folders.  Folders that don't exist will be created.
 
@@ -50,9 +50,24 @@ gulp.src('./client/templates/*.jade')
 ```
 
 #### path
-Type: `String`
+Type: `String` or `Function`
 
-The path (folder) to write files to.
+The path (output folder) to write files to. Or a function that returns it, the function will be provided a [vinyl File instance](https://github.com/wearefractal/vinyl).
+
+#### options
+Type: `Object`
+
+#### options.cwd
+Type: `String`
+Default: `process.cwd()`
+
+`cwd` for the output folder, only has an effect if provided output folder is relative.
+
+#### options.mode
+Type: `String`
+Default: `0777`
+
+Octal permission string specifying mode for any folders that need to be created for output folder.
 
 ### gulp.task(name[, deps], fn)
 


### PR DESCRIPTION
I had to read the code to figure out how to configure `gulp.dest` - was about to create my own plugin :)
