### PR TITLE
Add a complete jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,7 +10,7 @@
   "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
   "immed"         : true,     // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
   "indent"        : 2,        // {int} Number of spaces to use for indentation
-  "latedef"       : true,     // true: Require variables/functions to be defined before being used
+  "latedef"       : false,    // true: Require variables/functions to be defined before being used
   "newcap"        : false,    // true: Require capitalization of all constructor functions e.g. `new F()`
   "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
   "noempty"       : true,     // true: Prohibit use of empty blocks


### PR DESCRIPTION
This replaces the existing .jshintrc file with the complete one from https://github.com/jshint/jshint/blob/master/examples/.jshintrc - replacing values where needed. There are 3 intentions behind this PR. 
- Updating the .jshintrc when properties are deprecated/added is much easier when you are just tracking changes in the project's repo
- This version gives visibility into what rules can be tightened or loosened as the project needs them. 
- This version explicitly enumerates the rules since declarative > imperative

I also noticed that the test folder does not pass jshint. It's mostly quotation marks and line length but that may be worth fixing eventually.
