### PR TITLE
Add recipe for fast browserify builds (without watchify)

### DIFF
--- a/docs/recipes/fast-browserify-builds.md
+++ b/docs/recipes/fast-browserify-builds.md
@@ -51,7 +51,6 @@ gulp.task('build', function(done) {
     })
     .pipe(source('bundle.js'))
     .pipe(gulp.dest('./dist'));
-  }
 });
 
 gulp.task('watch', ['build'], function() {


### PR DESCRIPTION
By not using watchify you prevent having multiple watchers watch the same file (gulp uses gaze and watchify uses chokidar), and it seems easy enough to implement the caching ourselves.
