### PR TITLE
adds batched output for logging

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -179,18 +179,25 @@ function logEvents(gulpInst) {
   });
 
   gulpInst.on('task_start', function (e) {
-    // so when 5 tasks start at once it only logs one time with all 5
     var batched = '\'' + chalk.cyan(e.task) + '\'';
+    // logs once when tasks `start` at the same time
     batchThese('start', batched, function(batch){
-      gutil.log('Starting', batch.join(', '),'...');
+      gutil.log('Starting', batch.join(', '), '...');
     });
   });
 
   gulpInst.on('task_stop', function (e) {
     var time = prettyTime(e.hrDuration);
     var batched = '\''+chalk.cyan(e.task) +'\' after '+chalk.magenta(time);
+    // logs once tasks `stop` at the same time
     batchThese('stop', batched, function(batch){
-      gutil.log('Finished', batch.join(', ') );
+      // `stop` events have longer logs
+      if( batch.length < 3 ){
+        gutil.log('Finished', batch.join(', ') );
+        return ;
+      }
+      gutil.log('Finished', batch.slice(0, 2).join(', ') + ', ');
+      gutil.log( batch.slice(2).join(', ') );
     });
   });
 

--- a/lib/batchThese.js
+++ b/lib/batchThese.js
@@ -1,8 +1,11 @@
 'use strict';
 
 var timer = { }, batch = { };
+var limit = {
+  start : 5
+};
 
-module.exports = function (name, data, callback){
+function batchThese(name, data, callback){
 
   if(timer[name]){
     clearTimeout(timer[name]);
@@ -12,7 +15,8 @@ module.exports = function (name, data, callback){
   batch[name] = batch[name] || [];
   batch[name].push(data);
 
-  if( batch[name].length > 3 ){
+  var bound = limit[name] || 3;
+  if( batch[name].length > bound ){
     callback(batch[name]);
     delete batch[name];
     return ;
@@ -24,4 +28,6 @@ module.exports = function (name, data, callback){
     }
     delete batch[name];
   });
-};
+}
+
+module.exports = batchThese;


### PR DESCRIPTION
Recently I have been reading a lot the `bin` code and noticed [these lines](https://github.com/gulpjs/gulp/blob/master/bin/gulp.js#L181-L183). 
- adds `lib/batchThese.js`
- modifies logging for `task_start` and `task_stop` events so the output is batched. 

The reason for adding a batched output for `task_stop` is because sometimes the non-batched output for `task_stop` would write to `stdout` before the batch of `task_start`. I have took a constant length of 4 for the batch instead of 5 because on my 24'' monitor, when I have the terminal window at half the line breaks sometimes.
