### PR TITLE
more info on rimraf, maybe missing

### DIFF
--- a/docs/writing-a-plugin/README.md
+++ b/docs/writing-a-plugin/README.md
@@ -24,7 +24,7 @@ Vinyl files can have 3 possible forms for the contents attribute:
 
 - [Streams](dealing-with-streams.md)
 - [Buffers](using-buffers.md)
-- Empty (null) - Useful for things like rimraf, clean, where contents is not neeeded.
+- Empty (null) - Useful for things like [rimraf](https://www.npmjs.org/package/gulp-rimraf), clean, where contents is not neeeded.
 
 ## Useful resources
 


### PR DESCRIPTION
Some more information on [rimraf](https://www.npmjs.org/package/rimraf) maybe missing on the documentation of [writing a plugin](https://github.com/gulpjs/gulp/tree/master/docs/writing-a-plugin).
