### PR TITLE
Tell user the local version is used in case of version mismatch

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -100,6 +100,7 @@ function handleArguments(env) {
     gutil.log(chalk.red('Warning: gulp version mismatch:'));
     gutil.log(chalk.red('Global gulp is', cliPackage.version));
     gutil.log(chalk.red('Local gulp is', env.modulePackage.version));
+    gutil.log(chalk.red('Using local gulp'));
   }
 
   // chdir before requiring gulpfile to make sure


### PR DESCRIPTION
Judging from the code, it looks like the global version always calls the local one (https://github.com/gulpjs/gulp/blob/master/bin/gulp.js#L119). In case of a version mismatch, it might be helpful to point this out.
