### PR TITLE
Updated example code to use stream-combiner2

### DIFF
--- a/docs/recipes/combining-streams-to-handle-errors.md
+++ b/docs/recipes/combining-streams-to-handle-errors.md
@@ -2,17 +2,17 @@
 
 By default, emitting an error on a stream will cause it to be thrown unless it already has a listener attached to the `error` event. This gets a bit tricky when you're working with longer pipelines of streams.
 
-By using [multistream](https://github.com/feross/multistream) you can turn a series of streams into a single stream, meaning you only need to listen to the `error` event in one place in your code.
+By using [stream-combiner2](https://github.com/substack/stream-combiner2) you can turn a series of streams into a single stream, meaning you only need to listen to the `error` event in one place in your code.
 
 Here's an example of using it in a gulpfile:
 
 ```js
-var Multistream = require('multistream');
+var combiner = require('stream-combiner2');
 var uglify = require('gulp-uglify');
 var gulp = require('gulp');
 
 gulp.task('test', function() {
-  var combined = Multistream([
+  var combined = combiner.obj([
     gulp.src('bootstrap/js/*.js'),
     uglify(),
     gulp.dest('public/bootstrap')


### PR DESCRIPTION
Example code caused "Uncaught TypeError: Invalid non-string/buffer chunk"
