### PR TITLE
gulp-watch v3.0.0 API

### DIFF
--- a/docs/recipes/rebuild-only-files-that-change.md
+++ b/docs/recipes/rebuild-only-files-that-change.md
@@ -9,7 +9,7 @@ var watch = require('gulp-watch');
 
 gulp.task('default', function() {
   return gulp.src('sass/*.scss')
-    .pipe(watch())
+    .pipe(watch('sass/*.scss'))
     .pipe(sass())
     .pipe(gulp.dest('dist'));
 });


### PR DESCRIPTION
The gulp-watch API has changed with version 3.0.0. This PR updated the recipe to v3.0.0.
