### PR TITLE
update MIT License to year range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Fractal <contact@wearefractal.com>
+Copyright (c) 2013-2015 Fractal <contact@wearefractal.com>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
Copyright notices must reflect the current year. This commit updates the listed year to 2015 with a starting year of 2013.
https://github.com/gulpjs/gulp/commit/2357a4334051a6d1733037406ab7538255030d0b