### PR TITLE
Add templating example using Swig and YAML frontmatter

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -19,3 +19,4 @@
 * [Using multiple sources in one task](using-multiple-sources-in-one-task.md)
 * [Browserify + Uglify with sourcemaps](browserify-uglify-sourcemap.md)
 * [Output both a minified and non-minified version](minified-and-non-minified.md)
+* [Templating with Swig and YAML front-matter](templating-with-swig-and-yaml-front-matter.md)

--- a/docs/recipes/templating-with-swig-and-yaml-front-matter.md
+++ b/docs/recipes/templating-with-swig-and-yaml-front-matter.md
@@ -1,0 +1,49 @@
+# Templating with Swig and YAML front-matter
+Templating can be setup using `gulp-swig`, `gulp-data`, and `gulp-front-matter`:
+
+##### `page.html`
+
+```html
+---
+title: Things to do
+todos:
+    - First todo
+    - Another todo item
+    - A third todo item
+---
+<html>
+    <head>
+        <title>{{ title }}</title>
+    </head>
+    <body>
+        Things to do:
+        <ul>{% for todo in todos %}
+          <li>{{ todo }}</li>
+        {% endfor %}</ul>
+    </body>
+</html>
+```
+
+##### `gulpfile.js`
+
+```js
+var gulp = require('gulp');
+var swig = require('gulp-swig');
+var data = require('gulp-data');
+var fm   = require('gulp-front-matter');
+
+gulp.task("compile-page", function() {
+  gulp.src('page.html')
+      .pipe(fm({
+          property : 'vars',
+          remove   : true
+      }))
+      .pipe(data(function(page) { 
+          return page.vars;
+      }))
+      .pipe(swig())
+      .pipe(gulp.dest('build'));
+});
+
+gulp.task("default", ["compile-page"]);
+```

--- a/docs/recipes/templating-with-swig-and-yaml-front-matter.md
+++ b/docs/recipes/templating-with-swig-and-yaml-front-matter.md
@@ -33,10 +33,7 @@ var frontMatter = require('gulp-front-matter');
 
 gulp.task('compile-page', function() {
   gulp.src('page.html')
-      .pipe(frontMatter({
-          property: 'data',
-          remove: true
-      }))
+      .pipe(frontMatter({ property: 'data' }))
       .pipe(swig())
       .pipe(gulp.dest('build'));
 });

--- a/docs/recipes/templating-with-swig-and-yaml-front-matter.md
+++ b/docs/recipes/templating-with-swig-and-yaml-front-matter.md
@@ -16,7 +16,7 @@ todos:
         <title>{{ title }}</title>
     </head>
     <body>
-        Things to do:
+        <h1>{{ title }}</h1>
         <ul>{% for todo in todos %}
           <li>{{ todo }}</li>
         {% endfor %}</ul>

--- a/docs/recipes/templating-with-swig-and-yaml-front-matter.md
+++ b/docs/recipes/templating-with-swig-and-yaml-front-matter.md
@@ -1,5 +1,5 @@
 # Templating with Swig and YAML front-matter
-Templating can be setup using `gulp-swig`, `gulp-data`, and `gulp-front-matter`:
+Templating can be setup using `gulp-swig` and `gulp-front-matter`:
 
 ##### `page.html`
 
@@ -29,17 +29,13 @@ todos:
 ```js
 var gulp = require('gulp');
 var swig = require('gulp-swig');
-var data = require('gulp-data');
 var frontMatter = require('gulp-front-matter');
 
 gulp.task('compile-page', function() {
   gulp.src('page.html')
       .pipe(frontMatter({
-          property: 'vars',
+          property: 'data',
           remove: true
-      }))
-      .pipe(data(function(page) { 
-          return page.vars;
       }))
       .pipe(swig())
       .pipe(gulp.dest('build'));

--- a/docs/recipes/templating-with-swig-and-yaml-front-matter.md
+++ b/docs/recipes/templating-with-swig-and-yaml-front-matter.md
@@ -30,13 +30,13 @@ todos:
 var gulp = require('gulp');
 var swig = require('gulp-swig');
 var data = require('gulp-data');
-var fm   = require('gulp-front-matter');
+var frontMatter = require('gulp-front-matter');
 
-gulp.task("compile-page", function() {
+gulp.task('compile-page', function() {
   gulp.src('page.html')
-      .pipe(fm({
-          property : 'vars',
-          remove   : true
+      .pipe(frontMatter({
+          property: 'vars',
+          remove: true
       }))
       .pipe(data(function(page) { 
           return page.vars;
@@ -45,5 +45,5 @@ gulp.task("compile-page", function() {
       .pipe(gulp.dest('build'));
 });
 
-gulp.task("default", ["compile-page"]);
+gulp.task('default', ['compile-page']);
 ```


### PR DESCRIPTION
I was at a lack of documentation when trying to setup YAML front matter + templating for gulp. Here's a simple recipe for setting up gulp with YAML front matter and swig.