### PR TITLE
Removed syntax highlighting from file structure

### DIFF
--- a/docs/recipes/split-tasks-across-multiple-files.md
+++ b/docs/recipes/split-tasks-across-multiple-files.md
@@ -6,7 +6,7 @@ module.
 
 Imagine the following file structure:
 
-```sh
+```
 gulpfile.js
 tasks/
 ├── dev.js
@@ -20,7 +20,7 @@ Install the `require-dir` module:
 npm install --save-dev require-dir
 ```
 
-Add the following lines to your `gulpfile.js` file.
+Add the following lines to your `gulpfile.js` file:
 
 ```js
 var requireDir = require('require-dir');


### PR DESCRIPTION
Fenced code block used shell syntax highlighting, drawing attention to `test` unnecessarily:

![screen shot 2015-01-11 at 19 00 58](https://cloud.githubusercontent.com/assets/468093/5697960/8f9daca4-99c5-11e4-8edf-d57d9445916e.png)

Additionally, is there any advantage to declaring `var dir`? This works the same:

```js
var requireDir = require('require-dir');

requireDir('./tasks');
```