### PR TITLE
bundler should be hoisted in a task

### DIFF
--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -15,23 +15,31 @@ var buffer = require('vinyl-buffer');
 var watchify = require('watchify');
 var browserify = require('browserify');
 
-var bundler = watchify(browserify('./src/index.js', watchify.args));
-// add any other browserify options or transforms here
-bundler.transform('brfs');
+// bundle the javascripts
+gulp.task('bundle', function() {
+  var options = watchify.args;
+  options.fullPaths = false;
+  var bundler = watchify(browserify('./src/main.js', watchify.args));
+  // add any other browserify options or transforms here
+  bundler.transform('brfs');
 
-gulp.task('js', bundle); // so you can run `gulp js` to build the file
-bundler.on('update', bundle); // on any dep update, runs the bundler
+  // on any dep update, runs the bundler
+  bundler.on('update', function() {
+    bundle();
+  });
 
-function bundle() {
-  return bundler.bundle()
-    // log errors if they happen
-    .on('error', gutil.log.bind(gutil, 'Browserify Error'))
-    .pipe(source('bundle.js'))
-    // optional, remove if you dont want sourcemaps
-      .pipe(buffer())
-      .pipe(sourcemaps.init({loadMaps: true})) // loads map from browserify file
-      .pipe(sourcemaps.write('./')) // writes .map file
-    //
-    .pipe(gulp.dest('./dist'));
-}
+  function bundle() {
+    return bundler.bundle()
+      // log errors if they happen
+      .on('error', gutil.log.bind(gutil, 'Browserify Error'))
+      .pipe(source('bundle.js'))
+      // optional, remove if you dont want sourcemaps
+        .pipe(buffer())
+        .pipe(sourcemaps.init({loadMaps: true})) // loads map from browserify file
+        .pipe(sourcemaps.write('./')) // writes .map file
+      //
+      .pipe(gulp.dest('./build'));
+  }
+  return bundle();
+});
 ```


### PR DESCRIPTION
- bundler var should not be in global scope
- this is a rather gulpish way of defining tasks
- watchify.fullPaths is usually not used in browserify