### PR TITLE
Adds build logging to gulp/watchify recipe

### DIFF
--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -21,6 +21,7 @@ bundler.transform('brfs');
 
 gulp.task('js', bundle); // so you can run `gulp js` to build the file
 bundler.on('update', bundle); // on any dep update, runs the bundler
+bundler.on('log', gutil.log); // output build logs to terminal
 
 function bundle() {
   return bundler.bundle()


### PR DESCRIPTION
Uses gulp-util for time-stamped output of the same logs you'd get if you were running watchify directly.