### PR TITLE
Made browserify source maps actually work

### DIFF
--- a/docs/recipes/browserify-uglify-sourcemap.md
+++ b/docs/recipes/browserify-uglify-sourcemap.md
@@ -16,7 +16,7 @@ var sourcemaps = require('gulp-sourcemaps');
 gulp.task('javascript', function () {
   // transform regular node stream to gulp (buffered vinyl) stream 
   var browserified = transform(function(filename) {
-    var b = browserify(filename);
+    var b = browserify({entries: filename, debug: true});
     return b.bundle();
   });
   


### PR DESCRIPTION
They didn't work before I made this change.

https://github.com/substack/node-browserify#var-b--browserifyfiles-or-opts