### PR TITLE
Use different use of watchify in recipe

### DIFF
--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -15,7 +15,9 @@ var buffer = require('vinyl-buffer');
 var watchify = require('watchify');
 var browserify = require('browserify');
 
-var bundler = watchify(browserify('./src/index.js', watchify.args));
+var bundler = watchify(browserify(watchify.args));
+// add the file to bundle
+bundler.add('.src/index.js');
 // add any other browserify options or transforms here
 bundler.transform('brfs');
 


### PR DESCRIPTION
I don't know what the cause of this is. But I was absolutely not able to get the watchify recipe to work without changing the use of watchify to how it is in this PR.

This is also matches the examples given in the [watchify documentation](https://github.com/substack/watchify#var-w--watchifyb-opts).