### PR TITLE
docs(recipes): Browserify's undefined behavior is undefined.

### DIFF
--- a/docs/recipes/browserify-transforms.md
+++ b/docs/recipes/browserify-transforms.md
@@ -11,25 +11,23 @@ See also: the [Combining Streams to Handle Errors](https://github.com/gulpjs/gul
 
 var browserify = require('browserify');
 var gulp = require('gulp');
-var transform = require('vinyl-transform');
+var source = require('vinyl-source-stream');
+var buffer = require('vinyl-buffer');
 var gutil = require('gulp-util');
 var reactify = require('reactify');
 
 gulp.task('javascript', function () {
   // set up the browserify instance on a task basis
   var b = browserify({
+    entries: './entry.js',
     debug: true,
     // defining transforms here will avoid crashing your stream
     transform: [reactify]
   });
-  // transform regular node stream to gulp (buffered vinyl) stream
-  var browserified = transform(function(filename) {
-    b.add(filename);
-    return b.bundle();
-  });
 
-  return gulp.src('./app.js')
-    .pipe(browserified)
+  return b.bundle()
+    .pipe(source('app.js'))
+    .pipe(buffer())
     .pipe(sourcemaps.init({loadMaps: true}))
         // Add transformation tasks to the pipeline here.
         .pipe(uglify())

--- a/docs/recipes/browserify-uglify-sourcemap.md
+++ b/docs/recipes/browserify-uglify-sourcemap.md
@@ -11,22 +11,22 @@ See also: the [Combining Streams to Handle Errors](https://github.com/gulpjs/gul
 
 var browserify = require('browserify');
 var gulp = require('gulp');
-var transform = require('vinyl-transform');
+var source = require('vinyl-source-stream');
+var buffer = require('vinyl-buffer');
 var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
 var gutil = require('gulp-util');
 
 gulp.task('javascript', function () {
   // set up the browserify instance on a task basis
-  var b = browserify({debug: true});
-  // transform regular node stream to gulp (buffered vinyl) stream
-  var browserified = transform(function(filename) {
-    b.add(filename);
-    return b.bundle();
+  var b = browserify({
+    entries: './entry.js',
+    debug: true
   });
 
-  return gulp.src('./app.js')
-    .pipe(browserified)
+  return b.bundle()
+    .pipe(source('app.js'))
+    .pipe(buffer())
     .pipe(sourcemaps.init({loadMaps: true}))
         // Add transformation tasks to the pipeline here.
         .pipe(uglify())


### PR DESCRIPTION
b.bundle has always been documented as returning a readable stream. The fact that some versions return a duplex stream is an implementation detail, and writing to it results in undefined behavior.