### PR TITLE
add missing gulp-sourcemaps in browserify recipe

### DIFF
--- a/docs/recipes/browserify-transforms.md
+++ b/docs/recipes/browserify-transforms.md
@@ -15,6 +15,7 @@ var source = require('vinyl-source-stream');
 var buffer = require('vinyl-buffer');
 var gutil = require('gulp-util');
 var uglify = require('gulp-uglify');
+var sourcemaps = require('gulp-sourcemaps');
 var reactify = require('reactify');
 
 gulp.task('javascript', function () {

--- a/docs/recipes/browserify-with-globs.md
+++ b/docs/recipes/browserify-with-globs.md
@@ -16,6 +16,7 @@ var globby = require('globby');
 var through = require('through2');
 var gutil = require('gulp-util');
 var uglify = require('gulp-uglify');
+var sourcemaps = require('gulp-sourcemaps');
 var reactify = require('reactify');
 
 gulp.task('javascript', function () {


### PR DESCRIPTION
This pull request added missing `var sourcemaps = require('gulp-sourcemaps');` in browserify recipe.