### PR TITLE
checking for watch parameters, fixes #1002

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,12 @@ Gulp.prototype.src = vfs.src;
 Gulp.prototype.dest = vfs.dest;
 Gulp.prototype.symlink = vfs.symlink;
 Gulp.prototype.watch = function (glob, opt, task) {
+  if (typeof opt === 'string' || typeof task === 'string' ||
+    Array.isArray(opt) || Array.isArray(task)) {
+    throw new Error('watching ' + glob + ': watch task has to be ' +
+      'gulp.series, gulp.parallel or a function');
+  }
+
   if (typeof opt === 'function') {
     task = opt;
     opt = null;

--- a/test/watch.js
+++ b/test/watch.js
@@ -126,5 +126,29 @@ describe('gulp', function() {
       updateTempFile(tempFile);
     });
 
+    it('should throw an error: passed parameter (string) is not a function', function(done) {
+      var tempFile = path.join(outpath, 'empty.txt');
+
+      createTempFile(tempFile);
+      try {
+        gulp.watch(tempFile, 'task1');
+      } catch(err) {
+        err.message.should.equal('watching ' + tempFile +  ': watch task has to be gulp.series, gulp.parallel or a function');
+        done();
+      }
+    });
+
+    it('should throw an error: passed parameter (array) is not a function', function(done) {
+      var tempFile = path.join(outpath, 'empty.txt');
+
+      createTempFile(tempFile);
+      try {
+        gulp.watch(tempFile, ['task1']);
+      } catch(err) {
+        err.message.should.equal('watching ' + tempFile +  ': watch task has to be gulp.series, gulp.parallel or a function');
+        done();
+      }
+    });
+
   });
 });


### PR DESCRIPTION
This is the PR addressing #1002. I found out that we not only have to deal with strings, but also with arrays (they have been used in a lot of documentation, too). This check makes those four little lines I added extremely ugly and hard to read. Input on that one is appreciated (esp. from you, @phated).

Also, tests have been added.