### PR TITLE
Run JSHint on tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,6 +14,5 @@
   "strict": true,
   "undef": true,
   "unused": true,
-  "node": true,
-  "mocha": true
+  "node": true
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "prepublish": "marked-man --name gulp docs/CLI.md > gulp.1",
-    "lint": "jshint lib bin index.js --reporter node_modules/jshint-stylish/stylish.js --exclude node_modules && jscs lib bin test index.js",
+    "lint": "jshint lib bin test index.js --reporter node_modules/jshint-stylish/stylish.js --exclude node_modules && jscs lib bin test index.js",
     "test": "npm run-script lint && mocha --reporter spec",
     "coveralls": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "extends": "../.jshintrc",
+  "maxlen": null,
+  "mocha": true
+}

--- a/test/watch.js
+++ b/test/watch.js
@@ -22,8 +22,8 @@ describe('gulp', function() {
     var writeTimeout = 125; // Wait for it to get to the filesystem
     var writeFileWait = function(name, content, cb) {
       if (!cb) {
-        cb = function() {}
-      };
+        cb = function() {};
+      }
       setTimeout(function() {
         fs.writeFile(name, content, cb);
       }, writeTimeout);


### PR DESCRIPTION
JSHint was not run on the tests.

The failure is the same as in #1034, too long lines. Fix it, or ignore it in tests?