### PR TITLE
Add a hint for browserify transforms

### DIFF
--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -24,7 +24,7 @@ var customOpts = {
   debug: true
 };
 var opts = assign({}, watchify.args, customOpts);
-var b = watchify(browserify(opts));
+var b = watchify(browserify(opts)); // add transformations here, see https://github.com/substack/watchify/issues/187#issuecomment-89687576
 
 gulp.task('js', bundle); // so you can run `gulp js` to build the file
 b.on('update', bundle); // on any dep update, runs the bundler

--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -24,7 +24,10 @@ var customOpts = {
   debug: true
 };
 var opts = assign({}, watchify.args, customOpts);
-var b = watchify(browserify(opts)); // add transformations here, see https://github.com/substack/watchify/issues/187#issuecomment-89687576
+var b = watchify(browserify(opts)); 
+
+// add transformations here
+// i.e. b.transform(coffeeify);
 
 gulp.task('js', bundle); // so you can run `gulp js` to build the file
 b.on('update', bundle); // on any dep update, runs the bundler


### PR DESCRIPTION
I added browserify transforms in every call of `bundle()` and got increasing build times while running. 
Transformations have to be added once in the beginning as discussed in this question here: https://github.com/substack/watchify/issues/187#issuecomment-89687576 