### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,10 +63,5 @@
   "engines": {
     "node": ">= 0.9"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.githubusercontent.com/gulpjs/gulp/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/