### PR TITLE
Recipe: Accumulate end of the streams, not start

### DIFF
--- a/docs/recipes/make-stream-from-buffer.md
+++ b/docs/recipes/make-stream-from-buffer.md
@@ -95,7 +95,7 @@ gulp.task('write-versions', function() {
       stream.end();
     });
 
-    streamEnd = stream
+    streamEnd = streamEnd
     // transform the raw data into the stream, into a vinyl object/file
     .pipe(vinylBuffer())
     //.pipe(tap(function(file) { /* do something with the file contents here */ }))

--- a/docs/recipes/make-stream-from-buffer.md
+++ b/docs/recipes/make-stream-from-buffer.md
@@ -79,12 +79,13 @@ gulp.task('write-versions', function() {
   availableVersions.forEach(function(v) {
     // make a new stream with fake file name
     var stream = source('final.' + v);
+    
+    var streamEnd = stream;
+    
     // we load the data from the concatenated libs
     var fileContents = memory['libs.concat.js'] +
       // we add the version's data
       '\n' + memory.versions[v];
-
-    streams.push(stream);
 
     // write the file contents to the stream
     stream.write(fileContents);
@@ -94,11 +95,16 @@ gulp.task('write-versions', function() {
       stream.end();
     });
 
-    stream
+    streamEnd = stream
     // transform the raw data into the stream, into a vinyl object/file
     .pipe(vinylBuffer())
     //.pipe(tap(function(file) { /* do something with the file contents here */ }))
     .pipe(gulp.dest('output'));
+    
+    // add the end of the stream, otherwise the task would finish before all the processing
+    // is done
+    streams.push(streamEnd);
+    
   });
 
   return es.merge.apply(this, streams);


### PR DESCRIPTION
Currently, we accumulate the start of the streams. As a result, the task ends before later processing is finished.

In my case, the later processing takes 20 seconds so it's very apparent.