### PR TITLE
add quick links to api docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,11 @@
 ## gulp API docs
 
+Jump to:
+  [gulp.src](#gulpsrcglobs-options) |
+  [gulp.dest](#gulpdestpath-options) |
+  [gulp.task](#gulptaskname-deps-fn) |
+  [gulp.watch](#gulpwatchglob--opts-tasks-or-gulpwatchglob--opts-cb)
+
 ### gulp.src(globs[, options])
 
 Emits files matching provided glob or an array of globs. 


### PR DESCRIPTION
This is a suggestion PR. Every time I pull up the api docs, I wish these links were there. They're intentionally formatted to one line for minimal disruption.

Looks like this:
![gulp-api-links](https://cloud.githubusercontent.com/assets/2112202/8269992/c4b922ce-1792-11e5-93ae-69c69829e853.png)
