### PR TITLE
Make the recipe work for multiple levels of js directories and root

### DIFF
--- a/docs/recipes/running-task-steps-per-folder.md
+++ b/docs/recipes/running-task-steps-per-folder.md
@@ -45,7 +45,7 @@ gulp.task('scripts', function() {
       // minify
       // rename to folder.min.js
       // write to output again
-      return gulp.src(path.join(scriptsPath, folder, '/*.js'))
+      return gulp.src(path.join(scriptsPath, folder, '/**/*.js'))
         .pipe(concat(folder + '.js'))
         .pipe(gulp.dest(scriptsPath))
         .pipe(uglify())
@@ -53,7 +53,15 @@ gulp.task('scripts', function() {
         .pipe(gulp.dest(scriptsPath));
    });
 
-   return merge(tasks);
+   // process all remaining files in scriptsPath root into main.js and main.min.js files
+   var root = gulp.src(path.join(scriptsPath, '/*.js'))
+        .pipe(concat('main.js'))
+        .pipe(gulp.dest(scriptsPath))
+        .pipe(uglify())
+        .pipe(rename('main.min.js'))
+        .pipe(gulp.dest(scriptsPath));
+
+   return merge(tasks, root);
 });
 ```
 


### PR DESCRIPTION
Without the '/**' added the recipe is only useful for one level of subdirectories. With it, is usable for any number of them.
Also by adding the root variable as proposed also the root directory is processed.