### PR TITLE
Update gulp recipe bump-version-and-create-git-tag

### DIFF
--- a/docs/recipes/bump-version-and-create-git-tag.md
+++ b/docs/recipes/bump-version-and-create-git-tag.md
@@ -24,7 +24,7 @@ gulp.task('bump-version', function () {
 
 gulp.task('commit-changes', function () {
   return gulp.src('.')
-    .pipe(git.commit('[Prerelease] Bumped version number', {args: '-a'}));
+    .pipe(git.commit('[Prerelease] Bumped version number'));
 });
 
 gulp.task('push-changes', function (cb) {


### PR DESCRIPTION
When executing the old bump-version-and-create-git-tag recipe the `commit-changes` task threw the error  `fatal: Paths with -a does not make sense`

With removing the -a option everything works as expected (since it seems that the -a flag is default anyway)