### PR TITLE
Adds a git.add step in order to work on windows and linux

### DIFF
--- a/docs/recipes/automate-release-workflow.md
+++ b/docs/recipes/automate-release-workflow.md
@@ -44,6 +44,7 @@ gulp.task('bump-version', function () {
 
 gulp.task('commit-changes', function () {
   return gulp.src('.')
+    .pipe(git.add())
     .pipe(git.commit('[Prerelease] Bumped version number'));
 });
 


### PR DESCRIPTION
the git.commit command as currently stated doesn't work on all environments. With windows and git version 1.9.5.msysgit.1 it works but with centos and git version 1.8.3.1 it doesn't. By adding the git.add() step it works in both environments