### PR TITLE
Docs: Running Tasks In Series recipe 2nd example fix

### DIFF
--- a/docs/recipes/running-tasks-in-series.md
+++ b/docs/recipes/running-tasks-in-series.md
@@ -39,8 +39,10 @@ Another example, which returns the stream instead of using a callback:
 var gulp = require('gulp');
 var del = require('del'); // rm -rf
 
-gulp.task('clean', function(cb) {
-    del(['output'], cb);
+gulp.task('clean', function() {
+    // return the stream as the completion hint
+    // which the calling task(s) can use to know that this task has completed
+    return del(['output']);
 });
 
 gulp.task('templates', ['clean'], function() {


### PR DESCRIPTION
Second example is supposed to show returning a stream instead of using a callback. Commit b65a70c3ec291cd89caa14a73796098e778fdb07 changed the 'clean' task to use a callback. The 'templates' and 'styles' do return streams, but 'clean' is the only task anything actually needs to wait for, making it the focus of the example.