### PR TITLE
change recipe name bump-version-and-create-git-tag to automate-releas…

### DIFF
--- a/docs/recipes/automate-release-workflow.md
+++ b/docs/recipes/automate-release-workflow.md
@@ -1,4 +1,4 @@
-# Bump version number and create new Git tag
+# Automate release workflow
 
 If your project follows a semantic versioning, it may be a good idea to automatize the steps needed to do a release.
 Below you have a simple recipe that bumps the project version, commits the changes to git and creates a new tag.

--- a/docs/recipes/automate-release-workflow.md
+++ b/docs/recipes/automate-release-workflow.md
@@ -27,7 +27,7 @@ gulp.task('changelog', function () {
 gulp.task('github-release', function(done) {
   conventionalGithubReleaser({
     type: "oauth",
-    token: '0126af95c0e2d9b0a7c78738c4c00a860b04acc8'
+    token: '0126af95c0e2d9b0a7c78738c4c00a860b04acc8' // change this to your own GitHub token or use an environment variable
   }, {
     preset: 'angular' // Or to any other commit message convention you use.
   }, done);


### PR DESCRIPTION
…e-workflow

1. This recipe is about how to automate release workflow. It's not really about create git tag etc.
2. bump-version-and-create-git-tag is too long.