### PR TITLE
update dependencies

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,5 @@
 {
   "preset": "node-style-guide",
-  "maximumLineLength": null
+  "maximumLineLength": null,
+  "requireCapitalizedComments": null
 }

--- a/package.json
+++ b/package.json
@@ -34,29 +34,29 @@
     "minimist": "^1.1.0",
     "orchestrator": "^0.3.0",
     "pretty-hrtime": "^1.0.0",
-    "semver": "^4.1.0",
+    "semver": "^5.0.1",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^1.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",
-    "graceful-fs": "^3.0.0",
+    "graceful-fs": "^4.1.2",
     "istanbul": "^0.3.0",
-    "jscs": "~1.12.0",
+    "jscs": "^2.0.0",
     "jshint": "^2.5.0",
-    "jshint-stylish": "^1.0.0",
+    "jshint-stylish": "^2.0.1",
     "marked-man": "^0.1.3",
     "mkdirp": "^0.5.0",
     "mocha": "^2.0.1",
-    "mocha-lcov-reporter": "^0.0.1",
+    "mocha-lcov-reporter": "0.0.2",
     "q": "^1.0.0",
     "rimraf": "^2.2.5",
-    "should": "^5.0.1"
+    "should": "^7.0.3"
   },
   "scripts": {
     "prepublish": "marked-man --name gulp docs/CLI.md > gulp.1",
-    "lint": "jshint lib bin test index.js --reporter node_modules/jshint-stylish/stylish.js --exclude node_modules && jscs lib bin test index.js",
+    "lint": "jshint lib bin test index.js --reporter node_modules/jshint-stylish --exclude node_modules && jscs lib bin test index.js",
     "test": "npm run-script lint && mocha --reporter spec",
     "coveralls": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },


### PR DESCRIPTION
My main reason for this is for updating `vinyl-fs`, which use the latest `glob-stream`, which uses the latest `glob`, which allows for the `ignore` option to be passed into `gulp.src`.

Went ahead and updated all the latest other dependencies as well