### PR TITLE
Update readme and recipes to reflect new Promise-oriented `del`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ var paths = {
 
 // Not all tasks need to use streams
 // A gulpfile is just another node program and you can use any package available on npm
-gulp.task('clean', function(cb) {
+gulp.task('clean', function() {
   // You can use multiple globbing patterns as you would with `gulp.src`
-  del(['build'], cb);
+  return del(['build']);
 });
 
 gulp.task('scripts', ['clean'], function() {

--- a/docs/recipes/delete-files-folder.md
+++ b/docs/recipes/delete-files-folder.md
@@ -29,14 +29,14 @@ In the gulpfile we want to clean out the contents of the `mobile` folder before 
 var gulp = require('gulp');
 var del = require('del');
 
-gulp.task('clean:mobile', function (cb) {
-  del([
+gulp.task('clean:mobile', function () {
+  return del([
     'dist/report.csv',
     // here we use a globbing pattern to match everything inside the `mobile` folder
     'dist/mobile/**/*',
     // we don't want to clean this file though so we negate the pattern
     '!dist/mobile/deploy.json'
-  ], cb);
+  ]);
 });
 
 gulp.task('default', ['clean:mobile']);

--- a/docs/recipes/running-tasks-in-series.md
+++ b/docs/recipes/running-tasks-in-series.md
@@ -39,8 +39,8 @@ Another example, which returns the stream instead of using a callback:
 var gulp = require('gulp');
 var del = require('del'); // rm -rf
 
-gulp.task('clean', function(cb) {
-    del(['output'], cb);
+gulp.task('clean', function() {
+    return del(['output']);
 });
 
 gulp.task('templates', ['clean'], function() {


### PR DESCRIPTION
Pending [sindresorhus/del#29](https://github.com/sindresorhus/del/pull/29) and [sindresorhus/vinyl-paths#3](https://github.com/sindresorhus/vinyl-paths/pull/3). Do not merge yet.

This updates the gulp readme to reflect an upcoming version of `del` that returns a promise rather than receives a callback. It ends up cleaning its usage through gulp quite nicely since tasks can return promises to complete them \o/