### PR TITLE
Added documentation about tasks which only have dependencies

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -125,6 +125,12 @@ gulp.task('mytask', ['array', 'of', 'task', 'names'], function() {
 
 **Note:** Are your tasks running before the dependencies are complete?  Make sure your dependency tasks are correctly using the async run hints: take in a callback or return a promise or event stream.
 
+You can also omit the function if you only want to run the dependency tasks:
+
+```js
+gulp.task('build', ['array', 'of', 'task', 'names']);
+```
+
 #### fn
 
 The function that performs the task's operations. Generally this takes the form of `gulp.src().pipe(someplugin())`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -131,6 +131,8 @@ You can also omit the function if you only want to run the dependency tasks:
 gulp.task('build', ['array', 'of', 'task', 'names']);
 ```
 
+**Note:** The tasks will run in parallel (all at once), so don't assume that the tasks will start/finish in order.
+
 #### fn
 
 The function that performs the task's operations. Generally this takes the form of `gulp.src().pipe(someplugin())`.


### PR DESCRIPTION
It is possible to run tasks which only have dependencies, like so:
```js
gulp.task('build', ['array', 'of', 'task', 'names']);
```
So I added some documentation about it.