### PR TITLE
Set chokidar option ignoreIntial: true by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,12 +23,16 @@ Gulp.prototype.watch = function(glob, opt, task) {
 
   if (typeof opt === 'function') {
     task = opt;
-    opt = null;
+    opt = {};
   }
 
   var fn;
   if (typeof task === 'function') {
     fn = this.parallel(task);
+  }
+
+  if (opt.ignoreInitial == null) {
+    opt.ignoreInitial = true;
   }
 
   var watcher = chokidar.watch(glob, opt);


### PR DESCRIPTION
Chokidar by default emits `add` events as it initially scans the file tree it is asked to watch. This can be suppressed by setting the `ignoreInitial: true` option, which is desirable here to avoid kicking off the task for each matched file upon startup.

Users retain the ability to specify `ignoreInitial: false` if that is the behavior they want.

Resolves #1282 