### PR TITLE
update vinyl-fs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^2.1.1"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",


### PR DESCRIPTION
Issue: Default value set for highWaterMark in **through2 npm** is 16(max buffer length), when default buffer length exceeds all files are not written by **vinyl-fs v0.3.x** dest().

This issue is resolved in **vinyl-fs v2.1.x**