### PR TITLE
Update browserify globs example to work with the latest version of globby

### DIFF
--- a/docs/recipes/browserify-with-globs.md
+++ b/docs/recipes/browserify-with-globs.md
@@ -39,13 +39,7 @@ gulp.task('javascript', function () {
 
   // "globby" replaces the normal "gulp.src" as Browserify
   // creates it's own readable stream.
-  globby(['./entries/*.js'], function(err, entries) {
-    // ensure any errors from globby are handled
-    if (err) {
-      bundledStream.emit('error', err);
-      return;
-    }
-
+  globby(['./entries/*.js']).then(function(entries) {
     // create the Browserify instance.
     var b = browserify({
       entries: entries,
@@ -56,6 +50,9 @@ gulp.task('javascript', function () {
     // pipe the Browserify stream into the stream we created earlier
     // this starts our gulp pipeline.
     b.bundle().pipe(bundledStream);
+  }).catch(function(err) {
+    // ensure any errors from globby are handled
+    bundledStream.emit('error', err);
   });
 
   // finally, we return the stream, so gulp knows when this task is done.


### PR DESCRIPTION
The browserify globs example was no longer working with the latest version globby and I spent some time figuring out why. Turns out globby now uses Promise and has changed their API quite a bit.