### PR TITLE
upgraded to vinyl-fs@^2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^2.2.1"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",


### PR DESCRIPTION
vinyl-fs 2 `allowEmpty` when processing globs and is false by default.