### PR TITLE
Changed increment operators in tests to shorthand addition.

### DIFF
--- a/test/src.js
+++ b/test/src.js
@@ -123,7 +123,7 @@ describe('gulp input stream', function() {
       var a = 0;
       stream.on('error', done);
       stream.on('data', function() {
-        ++a;
+        a += 1;
       });
       stream.on('end', function() {
         a.should.equal(2);
@@ -136,7 +136,7 @@ describe('gulp input stream', function() {
       var stream = gulp.src(join(__dirname, './fixtures/test.coffee'));
       stream.on('error', done);
       stream.on('data', function(file) {
-        ++a;
+        a += 1;
         should.exist(file);
         should.exist(file.path);
         should.exist(file.contents);

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -23,11 +23,11 @@ describe('gulp tasks', function() {
       a = 0;
       fn = function() {
         this.should.equal(gulp);
-        ++a;
+        a += 1;
       };
       fn2 = function() {
         this.should.equal(gulp);
-        ++a;
+        a += 1;
       };
       gulp.task('test', fn);
       gulp.task('test2', fn2);
@@ -41,11 +41,11 @@ describe('gulp tasks', function() {
       a = 0;
       fn = function() {
         this.should.equal(gulp);
-        ++a;
+        a += 1;
       };
       fn2 = function() {
         this.should.equal(gulp);
-        ++a;
+        a += 1;
       };
       gulp.task('test', fn);
       gulp.task('test2', fn2);
@@ -61,7 +61,7 @@ describe('gulp tasks', function() {
       fn = function() {
         var deferred = Q.defer();
         setTimeout(function() {
-          ++a;
+          a += 1;
           deferred.resolve();
         }, 1);
         return deferred.promise;
@@ -69,7 +69,7 @@ describe('gulp tasks', function() {
       fn2 = function() {
         var deferred = Q.defer();
         setTimeout(function() {
-          ++a;
+          a += 1;
           deferred.resolve();
         }, 1);
         return deferred.promise;
@@ -90,13 +90,13 @@ describe('gulp tasks', function() {
       a = 0;
       fn = function(cb) {
         setTimeout(function() {
-          ++a;
+          a += 1;
           cb(null);
         }, 1);
       };
       fn2 = function(cb) {
         setTimeout(function() {
-          ++a;
+          a += 1;
           cb(null);
         }, 1);
       };
@@ -130,7 +130,7 @@ describe('gulp tasks', function() {
       a = 0;
       fn = function() {
         this.should.equal(gulp);
-        ++a;
+        a += 1;
       };
       gulp.task('test', fn);
       gulp.run('test');
@@ -144,7 +144,7 @@ describe('gulp tasks', function() {
       a = 0;
       fn = function() {
         this.should.equal(gulp);
-        ++a;
+        a += 1;
       };
       gulp.task('default', fn);
       gulp.run();

--- a/test/watch.js
+++ b/test/watch.js
@@ -149,7 +149,7 @@ describe('gulp', function() {
       fs.writeFile(tempFile, tempFileContent, function() {
 
         gulp.task(task1, function() {
-          a++;
+          a += 1;
         });
         gulp.task(task2, function() {
           a += 10;


### PR DESCRIPTION
Increment operators are [deprecated](https://jslinterrors.com/unexpected-plus-plus) in several javascript linting tools. The increment operators in the test cases are simply changed to shorthand addition (+= 1) 