### PR TITLE
Add browserify (multiple destination) example

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -20,5 +20,6 @@
 * [Using multiple sources in one task](using-multiple-sources-in-one-task.md)
 * [Browserify + Uglify with sourcemaps](browserify-uglify-sourcemap.md)
 * [Browserify + Globs](browserify-with-globs.md)
+* [Browserify + Globs (multiple destination)](browserify-multiple-destination.md)
 * [Output both a minified and non-minified version](minified-and-non-minified.md)
 * [Templating with Swig and YAML front-matter](templating-with-swig-and-yaml-front-matter.md)

--- a/docs/recipes/browserify-multiple-destination.md
+++ b/docs/recipes/browserify-multiple-destination.md
@@ -16,7 +16,7 @@ var uglify = require('gulp-uglify');
 
 gulp.task('js', function () {
 
-  return gulp.src('src/**/*.js', {base: 'src'})
+  return gulp.src('src/**/*.js', {read: false}) // no need of reading file because browserify does.
 
     // transform file objects using gulp-tap plugin
     .pipe(tap(function (file) {

--- a/docs/recipes/browserify-multiple-destination.md
+++ b/docs/recipes/browserify-multiple-destination.md
@@ -7,16 +7,19 @@ The below `js` task bundles all the `.js` files under `src/` as entry points and
 
 ```js
 var gulp = require('gulp');
-var plugins = require('gulp-load-plugins')();
 var browserify = require('browserify');
 var gutil = require('gulp-util');
+var tap = require('gulp-tap');
+var buffer = require('gulp-buffer');
+var sourcemaps = require('gulp-sourcemaps');
+var uglify = require('gulp-uglify');
 
 gulp.task('js', function () {
 
   return gulp.src('src/**/*.js', {base: 'src'})
 
-    // transform file objects using gulp-map plugin
-    .pipe(plugins.tap(function (file) {
+    // transform file objects using gulp-tap plugin
+    .pipe(tap(function (file) {
 
       gutil.log('bundling ' + file.path);
 
@@ -26,16 +29,15 @@ gulp.task('js', function () {
     }))
 
     // transform streaming contents into buffer contents (because gulp-sourcemaps does not support streaming contents)
-    .pipe(plugins.buffer())
+    .pipe(buffer())
 
     // load and init sourcemaps
-    .pipe(plugins.sourcemaps.init({loadMaps: true}))
+    .pipe(sourcemaps.init({loadMaps: true}))
 
-    // uglify
-    .pipe(plugins.uglify())
+    .pipe(uglify())
 
     // write sourcemaps
-    .pipe(plugins.sourcemaps.write('./'))
+    .pipe(sourcemaps.write('./'))
 
     .pipe(gulp.dest('dest'));
 

--- a/docs/recipes/browserify-multiple-destination.md
+++ b/docs/recipes/browserify-multiple-destination.md
@@ -1,0 +1,43 @@
+# Browserify + Globs (multiple destination)
+
+This example shows how to set up a task of bundling multiple entry points into multiple destinations using browserify.
+
+The below `js` task bundles all the `.js` files under `src/` as entry points and writes the results under `dest/`.
+
+
+```js
+var gulp = require('gulp');
+var plugins = require('gulp-load-plugins')();
+var browserify = require('browserify');
+var gutil = require('gulp-util');
+
+gulp.task('js', function () {
+
+  return gulp.src('src/**/*.js', {base: 'src'})
+
+    // transform file objects using gulp-map plugin
+    .pipe(plugins.tap(function (file) {
+
+      gutil.log('bundling ' + file.path);
+
+      // replace file contents with browserify's bundle stream
+      file.contents = browserify(file.path, {debug: true}).bundle();
+
+    }))
+
+    // transform streaming contents into buffer contents (because gulp-sourcemaps does not support streaming contents)
+    .pipe(plugins.buffer())
+
+    // load and init sourcemaps
+    .pipe(plugins.sourcemaps.init({loadMaps: true}))
+
+    // uglify
+    .pipe(plugins.uglify())
+
+    // write sourcemaps
+    .pipe(plugins.sourcemaps.write('./'))
+
+    .pipe(gulp.dest('dest'));
+
+});
+```


### PR DESCRIPTION
[Browserify+Globs](https://github.com/gulpjs/gulp/blob/master/docs/recipes/browserify-with-globs.md) recipe bundles everything into one bundle, but doesn't show how to bundle each file into a separate bundle.

I think this example is helpful for people who want to create separate bundles from different entry files.

[This blog post](https://wehavefaces.net/gulp-browserify-the-gulp-y-way-bb359b3f9623) covers almost the same thing, but because of the change of browserify API now the examples in the above post doesn't work. (see https://github.com/substack/node-browserify/issues/1217 )

I believe it's helpful for beginners to have this example in the official recipes.

Thanks,