### PR TITLE
Update browserify-with-globs.md

### DIFF
--- a/docs/recipes/browserify-with-globs.md
+++ b/docs/recipes/browserify-with-globs.md
@@ -49,7 +49,12 @@ gulp.task('javascript', function () {
 
     // pipe the Browserify stream into the stream we created earlier
     // this starts our gulp pipeline.
-    b.bundle().pipe(bundledStream);
+    b.bundle()
+      .on('error', function (error) {
+          gutil.log('Browserify Error', error.message);
+          this.emit('end');
+      })
+      .pipe(bundledStream);
   }).catch(function(err) {
     // ensure any errors from globby are handled
     bundledStream.emit('error', err);


### PR DESCRIPTION
when browserify throw this error
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: path must be a string
    at /.../node_modules/browserify/node_modules/resolve/lib/async.js:16:16
    at doNTCallback0 (node.js:428:9)
    at process._tickCallback (node.js:357:13)

we need some debugging information : added on('error'...) on the bundle