### PR TITLE
Setup Dockunit for More Comprehensive Continuous Tests

### DIFF
--- a/Dockunit.json
+++ b/Dockunit.json
@@ -1,0 +1,44 @@
+{
+  "containers": [
+    {
+      "prettyName": "nodejs latest",
+      "image": "node:latest",
+      "testCommand": "./node_modules/mocha/bin/mocha",
+      "beforeScripts": [
+        "npm install"
+      ]
+    },
+    {
+      "prettyName": "nodejs 5.0.0",
+      "image": "node:5.0.0",
+      "testCommand": "./node_modules/mocha/bin/mocha",
+      "beforeScripts": [
+        "npm install"
+      ]
+    },
+    {
+      "prettyName": "nodejs 4.2.1",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-4.2.1",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install"
+      ]
+    },
+    {
+      "prettyName": "nodejs 0.12.7",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-0.12.7",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install"
+      ]
+    },
+    {
+      "prettyName": "nodejs 0.10.40",
+      "image": "dockunit/prebuilt-images:nodejs-mongodb-mocha-jasmine-0.10.40",
+      "testCommand": "npm test",
+      "beforeScripts": [
+        "npm install"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[Dockunit](https://dockunit.io) is a continuous integration service built to be container based. It is super helpful because you can build and distribute your test environments from scratch and run tests locally with ease.

This PR tests Gulp in Node.js latest, 5.0.0, 4.2.1, 0.12.7, and 0.10.40. The versions available on Dockunit are much more extensive than that of Travis CI. Assuming the PR is accepted, I'll send another with the Dockunit status badge for the README.md. You can see the [current Dockunit status of Gulp here](https://dockunit.io/projects/tlovett1/gulp).