### PR TITLE
Surface 'on' listener functionality

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -163,14 +163,12 @@ gulp.task('jekyll', function(cb) {
     cb(); // finished task
   });
 });
-```
 
-##### Use a callback after a stream ends
-
-```javascript
+// use an async result in a pipe
 gulp.task('somename', function(cb) {
-  someAsyncAction(function(res) {
-    var stream = gulp.src('client/**/*.js')
+  getFilesAsync(function(err, res) {
+    if (err) return cb(err);
+    var stream = gulp.src(res)
       .pipe(minify())
       .pipe(gulp.dest('build'))
       .on('end', cb);

--- a/docs/API.md
+++ b/docs/API.md
@@ -165,6 +165,19 @@ gulp.task('jekyll', function(cb) {
 });
 ```
 
+##### Use a callback after a stream ends
+
+```javascript
+gulp.task('somename', function(cb) {
+  someAsyncAction(function(res) {
+    var stream = gulp.src('client/**/*.js')
+      .pipe(minify())
+      .pipe(gulp.dest('build'))
+      .on('end', cb);
+  });
+});
+```
+
 ##### Return a stream
 
 ```js


### PR DESCRIPTION
It is not apparent from the docs that src can be listened for when it finishes, which is immensely useful if performing a pipe after an asynchronous result. I've added an example to the documentation to surface this functionality, since I lost several hours puzzling over how to accomplish this task.