### PR TITLE
refactor version for tasks compose

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,16 @@
 'use strict';
 
 var util = require('util');
-var Orchestrator = require('orchestrator');
 var gutil = require('gulp-util');
 var deprecated = require('deprecated');
 var vfs = require('vinyl-fs');
+var Tasks = require('./lib/tasks');
 
 function Gulp() {
-  Orchestrator.call(this);
+  Tasks.call(this);
 }
-util.inherits(Gulp, Orchestrator);
+util.inherits(Gulp, Tasks);
 
-Gulp.prototype.task = Gulp.prototype.add;
 Gulp.prototype.run = function() {
   // `run()` is deprecated as of 3.5 and will be removed in 4.0
   // Use task dependencies instead
@@ -19,7 +18,7 @@ Gulp.prototype.run = function() {
   // Impose our opinion of "default" tasks onto orchestrator
   var tasks = arguments.length ? arguments : ['default'];
 
-  this.start.apply(this, tasks);
+  return this.start.apply(this, tasks);
 };
 
 Gulp.prototype.src = vfs.src;

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -1,0 +1,181 @@
+'use strict';
+
+var util = require('util');
+var Stream = require('stream');
+var thunks = require('thunks');
+var thunkStream = require('thunk-stream');
+var EventEmitter = require('events').EventEmitter;
+var slice = Array.prototype.slice;
+var thunk = thunks();
+
+module.exports = Tasks;
+
+function Tasks() {
+  this.actors = [];
+  this.isRunning = false;
+  this.tasks = Object.create(null);
+  EventEmitter.call(this);
+}
+
+util.inherits(Tasks, EventEmitter);
+
+Tasks.prototype.task = function(name, dep, task) {
+  if (typeof name !== 'string') {
+    throw new Error('Task requires a name that is a string');
+  }
+  if (this.tasks[name]) {
+    throw new Error('Task ' + name + ' exists');
+  }
+  if (!Array.isArray(dep)) {
+    task = dep;
+    dep = [];
+  }
+
+  task = task || noOp;
+  if (typeof task !== 'function') {
+    throw new Error('Task ' + name + ' requires a body that is a function');
+  }
+  this.tasks[name] = new Task(name, task, dep);
+  return this;
+};
+
+Tasks.prototype.start = function() {
+  var args = slice.call(arguments);
+  var cb = args[args.length - 1];
+  if (typeof cb !== 'function') {
+    cb = null;
+  } else {
+    args = args.slice(0, -1);
+  }
+
+  if (!args.length) {
+    args.push('default');
+  }
+  this.isRunning = true;
+  this.emit('start', args);
+  var tasks = thunk.call(this, this.co.apply(this, args))(function(err) {
+    this.cleanup();
+    if (err) {
+      this.emit('error', err);
+      this.emit('err', err); // Back compatible
+      throw err;
+    }
+    this.emit('stop');
+  });
+  return cb ? tasks(cb) : tasks;
+};
+
+Tasks.prototype.co = function() {
+  var ctx = this;
+  var args = slice.call(arguments);
+  return function(done) {
+    return thunk.seq(evalTasks.call(ctx, args, true))(done);
+  };
+};
+
+Tasks.prototype.all = function(tasks) {
+  var ctx = this;
+  tasks = Array.isArray(tasks) ? tasks : slice.call(arguments);
+  return function(done) {
+    thunk.all(evalTasks.call(ctx, tasks))(done);
+  };
+};
+
+Tasks.prototype.seq = function(tasks) {
+  var ctx = this;
+  tasks = Array.isArray(tasks) ? tasks : slice.call(arguments);
+  return function(done) {
+    thunk.seq(evalTasks.call(ctx, tasks))(done);
+  };
+};
+
+Tasks.prototype.cleanup = function() {
+  this.actors.map(function(name) {
+    var task = this[name];
+    task.fnPromise = null;
+    task.duration = 0;
+    task.hrDuration = 0;
+  }, this.tasks);
+  this.isRunning = false;
+  this.actors.length = 0;
+};
+
+Tasks.prototype.reset = function() {
+  this.cleanup();
+  this.tasks = Object.create(null);
+};
+
+function evalTask(name) {
+  var task = this.tasks[name];
+  if (!task) {
+    var err = new Error('Task ' + name + ' not found');
+    taskEmit(this, name, 'not_found', err);
+    throw err;
+  }
+  this.actors.push(name);
+  return thunk.call(this, function(done) {
+    var tasks = [task.eval(this)];
+    if (task.dep.length) {
+      tasks.unshift(thunk.all(evalTasks.call(this, task.dep)));
+    }
+    thunk.seq(tasks)(done);
+  });
+};
+
+function evalTasks(tasks, evalSub) {
+  return tasks.map(function(name) {
+    if (evalSub && Array.isArray(name)) {
+      return thunk.all(evalTasks.call(this, name));
+    }
+    return evalTask.call(this, name);
+  }, this);
+}
+
+function Task(name, task, dep) {
+  this.fn = task;
+  this.dep = dep;
+  this.name = name;
+  this.duration = 0; // Seconds
+  this.hrDuration = 0; // [seconds,nanoseconds]
+  this.fnPromise = null;
+}
+
+Task.prototype.eval = function(parent) {
+  var ctx = this;
+  this.fnPromise = this.fnPromise || thunk.persist(function(callback) {
+    ctx.duration = 0;
+    ctx.hrDuration = 0;
+    taskEmit(parent, ctx.name, 'start');
+
+    var start = process.hrtime();
+    var target = ctx.fn.length ? ctx.fn : ctx.fn.call(parent);
+    var handle = target instanceof Stream ? thunkStream : thunk;
+
+    handle.call(parent, target)(function(err) {
+      ctx.hrDuration = process.hrtime(start);
+      ctx.duration = ctx.hrDuration[0] + (ctx.hrDuration[1] / 1e9);
+      if (err) {
+        taskEmit(parent, ctx.name, 'err', err);
+        throw err;
+      }
+      taskEmit(parent, ctx.name, 'stop', {
+        hrDuration: ctx.hrDuration,
+        duration: ctx.duration,
+      });
+    })(callback);
+  });
+  return this.fnPromise;
+};
+
+function noOp() {}
+
+function taskEmit(ctx, taskName, eventName, data) {
+  data = data || {};
+  if (eventName === 'err') {
+    data.err = data; // Back compatible
+  }
+  data.task = taskName;
+  data.src = 'task_' + eventName;
+  data.message = data.message || taskName + ' ' + eventName;
+  ctx.emit(data.src, data);
+}

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
     "interpret": "^1.0.0",
     "liftoff": "^2.1.0",
     "minimist": "^1.1.0",
-    "orchestrator": "^0.3.0",
     "pretty-hrtime": "^1.0.0",
     "semver": "^4.1.0",
+    "thunk-stream": "^1.1.1",
+    "thunks": "^4.1.1",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
     "vinyl-fs": "^0.3.0"

--- a/test/tasks.js
+++ b/test/tasks.js
@@ -31,7 +31,7 @@ describe('gulp tasks', function() {
       };
       gulp.task('test', fn);
       gulp.task('test2', fn2);
-      gulp.run('test', 'test2');
+      gulp.start('test', 'test2');
       a.should.equal(2);
       gulp.reset();
       done();
@@ -49,8 +49,8 @@ describe('gulp tasks', function() {
       };
       gulp.task('test', fn);
       gulp.task('test2', fn2);
-      gulp.run('test');
-      gulp.run('test2');
+      gulp.start('test');
+      gulp.start('test2');
       a.should.equal(2);
       gulp.reset();
       done();
@@ -76,8 +76,8 @@ describe('gulp tasks', function() {
       };
       gulp.task('test', fn);
       gulp.task('test2', fn2);
-      gulp.run('test');
-      gulp.run('test2', function() {
+      gulp.start('test');
+      gulp.start('test2', function() {
         gulp.isRunning.should.equal(false);
         a.should.equal(2);
         gulp.reset();
@@ -102,8 +102,8 @@ describe('gulp tasks', function() {
       };
       gulp.task('test', fn);
       gulp.task('test2', fn2);
-      gulp.run('test');
-      gulp.run('test2', function() {
+      gulp.start('test');
+      gulp.start('test2', function() {
         gulp.isRunning.should.equal(false);
         a.should.equal(2);
         gulp.reset();
@@ -120,7 +120,7 @@ describe('gulp tasks', function() {
         done();
       });
       try {
-        gulp.run('test');
+        gulp.start('test');
       } catch (err) {
         should.exist(err);
       }
@@ -133,7 +133,7 @@ describe('gulp tasks', function() {
         ++a;
       };
       gulp.task('test', fn);
-      gulp.run('test');
+      gulp.start('test');
       a.should.equal(1);
       gulp.isRunning.should.equal(false);
       gulp.reset();
@@ -147,7 +147,7 @@ describe('gulp tasks', function() {
         ++a;
       };
       gulp.task('default', fn);
-      gulp.run();
+      gulp.start();
       a.should.equal(1);
       gulp.isRunning.should.equal(false);
       gulp.reset();


### PR DESCRIPTION
Hi, @callumacrae
I have removed [standard](https://github.com/feross/standard) coding style as https://github.com/gulpjs/gulp/pull/1462.
It is now less changes.

What I bring to gulp here:

### support five task type:
1. sync task;
2. callback task;
3. promise task;
4. stream task;
5. generator task(async/await task later);

Here is generator task will like be:
```js
gulp.task('generator_task', function *() {
  yield somePromise;
  yield someThunk;
  yield gulp.all('a', 'b', 'c');
  yield gulp.seq('e', 'f', 'g');
  yield gulp.co('h', 'i', ['g', 'k'], 'l');
  // others ...
});
```

### tasks compose:

### gulp.start('task1', 'task2', ...[, cb])
Run tasks in order. Return thunk function.

```js
// Run 'default' task
gulp.start();
// Run 'default' task with callback
gulp.start(cb);
gulp.start()(cb);

// Run tasks 'a', 'b', 'c' in sequence
gulp.start('a', 'b', 'c');
// with callback
gulp.start('a', 'b', 'c', cb);
gulp.start('a', 'b', 'c')(cb);

// Run tasks 'a', 'b', 'c' in parallel
gulp.start(['a', 'b', 'c']);
// with callback
gulp.start(['a', 'b', 'c'], cb);
gulp.start(['a', 'b', 'c'])(cb);

// Run tasks 'a', then run 'b', 'c' in parallel, then run 'd'
gulp.start('a', ['b', 'c'], 'd');
// with callback
gulp.start('a', ['b', 'c'], 'd', cb);
gulp.start('a', ['b', 'c'], 'd')(cb);
```

### gulp.co('task1', 'task2', ...)
Compose tasks in order. It return thunk function that contain the tasks. The tasks will not run until you call the thunk function.

```js
// Compose tasks 'a', 'b', 'c', tasks will run in sequence
gulp.co('a', 'b', 'c');
// Compose tasks 'a', 'b', 'c', tasks will run in parallel
gulp.co(['a', 'b', 'c']);
// Compose tasks 'a', 'b', 'c', task 'a' will run first, then 'b', 'c' in parallel, then 'd'.
gulp.co('a', ['b', 'c'], 'd');
```

Define a task with `gulp.co`
```js
gulp.task('build', gulp.co('a', ['b', 'c'], 'd'));
// run it
gulp.start('build');
```

### gulp.all('task1', 'task2', ...)
Compose tasks in parallel. It return thunk function that contain the tasks. The tasks will not run until you call the thunk function.

```js
// Compose tasks 'a', 'b', 'c', tasks will run in parallel
gulp.all('a', 'b', 'c');
gulp.all(['a', 'b', 'c']);
```

Define a task with `gulp.all`
```js
gulp.task('build', gulp.all('a', 'b', 'c'));
// run it
gulp.start('build');
```

### gulp.seq('task1', 'task2', ...)
Compose tasks in sequence. It return thunk function that contain the tasks. The tasks will not run until you call the thunk function.

```js
// Compose tasks 'a', 'b', 'c', tasks will run in sequence
gulp.seq('a', 'b', 'c');
gulp.seq(['a', 'b', 'c']);
```


Define a task with `gulp.seq`
```js
gulp.task('build', gulp.seq('a', 'b', 'c'));
// run it
gulp.start('build');
```