### PR TITLE
Wrap chokadir callbacks in an additional function to solve some under…

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,9 +47,9 @@ Gulp.prototype.watch = function(glob, opt, task) {
   var watcher = chokidar.watch(glob, opt);
   if (fn) {
     watcher
-      .on('change', fn)
-      .on('unlink', fn)
-      .on('add', fn);
+      .on('change', function() { fn(); })
+      .on('unlink', function() { fn(); })
+      .on('add', function() { fn(); });
   }
 
   return watcher;


### PR DESCRIPTION
…lying problems with undertaker and bach in combination with undertaker's _settle flag.

Chokadir passes the path of the added/removed/changed file to his event callbacks which will end up being the `done` parameter inside bach's `buildParallel` `parallel` function, this doesn't seem to be noticeable without the `_settle` flag set to `true` but could lead to some future hard to trace down bugs.

Solves #1487 partially.