### PR TITLE
Make watch() work without opts or callback

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -481,7 +481,7 @@ Type: `Array`, `String` or `Function`
 A task name, a function or an array of either.
 
 
-### gulp.watch(glob[, opts], fn)
+### gulp.watch(glob[, opts][, fn])
 
 Watch files and do something when a file changes.
 File watching is provided by the [`chokidar`][chokidar] module.
@@ -492,7 +492,7 @@ Please report any file watching problems directly to its
 gulp.watch('js/**/*.js', gulp.parallel('uglify', 'reload'));
 ```
 
-In the example, `gulp.watch` runs the function returned by gulp.parallel each
+In the example, `gulp.watch` runs the function returned by `gulp.parallel` each
 time a file with the `js` extension in `js/` is updated.
 
 #### glob
@@ -525,12 +525,14 @@ Read about the full set of options in [`chokidar`'s README][chokidar].
 #### fn
 Type: `Function`
 
-An [async](#async-support) function to run when a file changes.
+An [async](#async-support) function to run when a file changes. Does not provide
+access to the `path` parameter.
 
 `gulp.watch` returns a wrapped [chokidar] FSWatcher object. If provided,
 the callback will be triggered upon any `add`, `change`, or `unlink` event.
 Listeners can also be set directly for any of [chokidar]'s events, such as
-`addDir`, `unlinkDir`, and `error`.
+`addDir`, `unlinkDir`, and `error`. You must set listeners directly to get
+access to chokidar's callback parameters, such as `path`.
 
 ```js
 var watcher = gulp.watch('js/**/*.js', gulp.parallel('uglify', 'reload'));
@@ -546,7 +548,7 @@ watcher.on('unlink', function(path) {
 ##### path
 Type: `String`
 
-The relative path of the document.
+Path to the file. If `opts.cwd` is set, `path` is relative to it.
 
 ##### stats
 Type: `Object`

--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ Gulp.prototype.watch = function(glob, opt, task) {
     opt = {};
   }
 
+  opt = opt || {};
+
   var fn;
   if (typeof task === 'function') {
     fn = this.parallel(task);

--- a/test/watch.js
+++ b/test/watch.js
@@ -126,6 +126,10 @@ describe('gulp', function() {
       updateTempFile(tempFile);
     });
 
+    it('should work without options or callback', function() {
+      gulp.watch('x');
+    });
+
     it('should run many tasks: w/ options', function(done) {
       var tempFile = path.join(outpath, 'watch-task-options.txt');
       var a = 0;


### PR DESCRIPTION
Except for the method signature in the end user docs, every indication is that `watch()` is supposed to work without a callback. But as a result of #1283, if you pass neither opts nor a callback it throws. This fixes that and updates the documentation of the method signature, and the prose about how callback is invoked.