### PR TITLE
add gulp.requireNodeFlags

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -113,7 +113,17 @@ function handleArguments(env) {
   }
 
   // This is what actually loads up the gulpfile
-  require(env.configPath);
+  try {
+    require(env.configPath);
+  } catch (e) {
+    if (e.missingFlags) {
+      var respawn = require('flagged-respawn/lib/respawn');
+      respawn([process.argv[0]].concat(process.execArgv).concat(e.missingFlags).concat(process.argv.slice(1)));
+      return;
+    } else {
+      throw e;
+    }
+  }
   gutil.log('Using gulpfile', chalk.magenta(tildify(env.configPath)));
 
   var gulpInst = require(env.modulePath);

--- a/index.js
+++ b/index.js
@@ -40,6 +40,21 @@ Gulp.prototype.watch = function(glob, opt, fn) {
   return vfs.watch(glob, opt, fn);
 };
 
+function MissingFlagsError(missingFlags) {
+  Error.call(this);
+  this.missingFlags = missingFlags;
+}
+util.inherits(MissingFlagsError, Error);
+
+Gulp.prototype.requireNodeFlags = function () {
+  var missingFlags = Array.prototype.filter.call(arguments, function (arg) {
+    return process.execArgv.indexOf(arg) < 0;
+  });
+  if (missingFlags.length) {
+    throw new MissingFlagsError(missingFlags);
+  }
+};
+
 // Let people use this class from our instance
 Gulp.prototype.Gulp = Gulp;
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "archy": "^1.0.0",
     "chalk": "^1.0.0",
     "deprecated": "^0.0.1",
+    "flagged-respawn": "^0.3.1",
     "gulp-util": "^3.0.0",
     "interpret": "^1.0.0",
     "liftoff": "^2.1.0",


### PR DESCRIPTION
This is a work in progress; I'd want to add documentation and tests but I wanted to toss the basic idea out there to see if there's heavy pushback first.

This provides a way for a gulpfile or a gulp plugin to specify that it requires special Node.js flags (like `--harmony_proxies`). Adding `gulp.requireNodeFlags('--harmony_proxies', ...)` to the top of a gulpfile is all that's required. It reuses the same respawn code that gets used currently when using Node.js flags as arguments to gulp, so instead of getting an error message if you forget to invoke gulp with the right things, gulp just quietly restarts with the missing flags added.

I'm torn on whether `requireNodeFlags` should go here or in `gulp-utils`; the latter feels slightly more correct if I expect plugins and not just gulpfiles to use this, but then I'd have two PRs to wrangle so I figured I'd get confirmation on that from you all first.

Feedback please?