### PR TITLE
Added new gulpfile sample to README file with ES2015 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Node already supports a lot of **ES2015**, to avoid compatibility problem we sug
 npm install --save-dev babel-core -babel-preset-es2015
 ```
 
-Then create a **.babelrc** file with the rpeset configuration.
+Then create a **.babelrc** file with the preset configuration.
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -108,7 +108,15 @@ Node already supports a lot of **ES2015**, to avoid compatibility problem we sug
 npm install --save-dev babel-core -babel-preset-es2015
 ```
 
-Here's the same sample from above written in **ES2015**.
+Then create a **.babelrc** file with the rpeset configuration.
+
+```js
+{
+  "presets": [ "es2015" ]
+}
+```
+
+And here's the same sample from above written in **ES2015**.
 
 ```js
 import gulp from 'gulp';

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ For a Getting started guide, API docs, recipes, making a plugin, etc. see the [d
 This file is just a quick sample to give you a taste of what gulp does.
 
 ```js
-var gulp = require('gulp'),
-  rename = require('gulp-rename'),
-  less = require('gulp-less'),
-  cssmin = require('gulp-cssmin'),
-  concat = require('gulp-concat'),
-  uglify = require('gulp-uglify'),
-  del = require('del');
+var gulp = require('gulp');
+var rename = require('gulp-rename');
+var less = require('gulp-less');
+var cssmin = require('gulp-cssmin');
+var concat = require('gulp-concat');
+var uglify = require('gulp-uglify');
+var del = require('del');
 
 var paths = {
   styles: {
@@ -70,7 +70,7 @@ function styles() {
 function scripts() {
   return gulp.src(paths.scripts.src)
     .pipe(uglify())
-    .pipe(concat(main.min.js))
+    .pipe(concat('main.min.js'))
     .pipe(gulp.dest(paths.scripts.dest));
 }
 
@@ -89,15 +89,12 @@ gulp.task(watch);
  * Notice that you can specify if tasks can run in parallel or not
  * using `gulp.series` and `gulp.parallel`
  */
-gulp.task('build',
-  gulp.series(clean),
-  gulp.parallel(styles, scripts));
+gulp.task('build', gulp.series(clean, gulp.parallel(styles, scripts)));
 
 /*
  * Expose default task that can be called by just running `gulp` from cli
  */
-gulp.task('default',
-  gulp.series(build))
+gulp.task('default', build);
 ```
 
 ## Use last JavaScript version in your gulpfile
@@ -156,7 +153,7 @@ function styles() {
 function scripts() {
   return gulp.src(paths.scripts.src)
     .pipe(uglify())
-    .pipe(concat(main.min.js))
+    .pipe(concat('main.min.js'))
     .pipe(gulp.dest(paths.scripts.dest));
 }
 
@@ -168,12 +165,9 @@ function watch() {
 gulp.task(clean);
 gulp.task(watch);
 
-gulp.task('build',
-  gulp.series(clean),
-  gulp.parallel(styles, scripts));
+gulp.task('build', gulp.series(clean, gulp.parallel(styles, scripts)));
 
-gulp.task('default',
-  gulp.series('build'))
+gulp.task('default', build);
 ```
 
 ## Incremental Builds

--- a/README.md
+++ b/README.md
@@ -23,67 +23,149 @@ For a Getting started guide, API docs, recipes, making a plugin, etc. see the [d
 This file is just a quick sample to give you a taste of what gulp does.
 
 ```js
-var gulp = require('gulp');
-var coffee = require('gulp-coffee');
-var concat = require('gulp-concat');
-var uglify = require('gulp-uglify');
-var imagemin = require('gulp-imagemin');
-var sourcemaps = require('gulp-sourcemaps');
-var del = require('del');
+var gulp = require('gulp'),
+  rename = require('gulp-rename'),
+  less = require('gulp-less'),
+  cssmin = require('gulp-cssmin'),
+  concat = require('gulp-concat'),
+  uglify = require('gulp-uglify'),
+  del = require('del');
 
 var paths = {
-  scripts: ['client/js/**/*.coffee', '!client/external/**/*.coffee'],
-  images: 'client/img/**/*'
+  styles: {
+    src: 'src/styles/**/*.less',
+    dest: 'assets/styles/'
+  },
+  scripts: {
+    src: 'src/scripts/**/*.js',
+    dest: 'assets/scripts/'
+  }
 };
 
-/* Register some tasks to expose to the cli */
-gulp.task('build', gulp.series(
-  clean,
-  gulp.parallel(scripts, images)
-));
+/* Not all tasks need to use streams, a gulpfile is just another node program
+ * and you can use all packages available on npm, but it must return either a
+ * Promise, a Stream or take a callback and call it
+ */
+function clean() {
+  // You can use multiple globbing patterns as you would with `gulp.src`,
+  // for example if you are using del 2.0 or above, return its promise
+  del([ 'assets' ]);
+}
+
+/* 
+ * Define our tasks using plain functions
+ */
+function styles() {
+  return gulp.src(paths.styles.src)
+    .pipe(less())
+    .pipe(cssmin())
+    // pass in options to the task
+    .pipe(rename({
+          basename: 'main',
+          suffix: '.min'
+        }))
+    .pipe(gulp.dest(paths.styles.dest));
+}
+
+function scripts() {
+  return gulp.src(paths.scripts.src)
+    .pipe(uglify())
+    .pipe(concat(main.min.js))
+    .pipe(gulp.dest(paths.scripts.dest));
+}
+
+function watch() {
+  gulp.watch(paths.scripts.src, scripts);
+  gulp.watch(paths.styles.src, styles);
+}
+
+/* 
+ * Register some tasks to expose to the cli
+ */
 gulp.task(clean);
 gulp.task(watch);
 
-// The default task (called when you run `gulp` from cli)
-gulp.task('default', gulp.series('build'));
+/* 
+ * Notice that you can specify if tasks can run in parallel or not
+ * using `gulp.series` and `gulp.parallel`
+ */
+gulp.task('build',
+  gulp.series(clean),
+  gulp.parallel(styles, scripts));
 
+/*
+ * Expose default task that can be called by just running `gulp` from cli
+ */
+gulp.task('default',
+  gulp.series(build))
+```
 
-/* Define our tasks using plain functions */
+## Use last JavaScript version in your gulpfile
 
-// Not all tasks need to use streams
-// A gulpfile is just another node program and you can use all packages available on npm
-// But it must return either a Promise or Stream or take a Callback and call it
+Node already supports a lot of **ES2015**, to avoid compatibility problem we suggest to install Babel and rename your `gulpfile.js` as `gulpfile.babel.js`.
+
+```sh
+npm install --save-dev babel-core -babel-preset-es2015
+```
+
+Here's the same sample from above written in **ES2015**.
+
+```js
+import gulp from 'gulp';
+import rename from 'gulp-rename';
+import less from 'gulp-less';
+import cssmin from 'gulp-cssmin';
+import concat from 'gulp-concat';
+import uglify from 'gulp-uglify';
+import del from 'del';
+
+const paths = {
+  styles: {
+    src: 'src/styles/**/*.less',
+    dest: 'assets/styles/'
+  },
+  scripts: {
+    src: 'src/scripts/**/*.js',
+    dest: 'assets/scripts/'
+  }
+};
+
 function clean() {
-  // You can use multiple globbing patterns as you would with `gulp.src`
-  // If you are using del 2.0 or above, return its promise
-  return del(['build']);
+  del([ 'assets' ]);
 }
 
-// Copy all static images
-function images() {
-  return gulp.src(paths.images)
-    // Pass in options to the task
-    .pipe(imagemin({optimizationLevel: 5}))
-    .pipe(gulp.dest('build/img'));
+function styles() {
+  return gulp.src(paths.styles.src)
+    .pipe(less())
+    .pipe(cssmin())
+    .pipe(rename({
+          basename: 'main',
+          suffix: '.min'
+        }))
+    .pipe(gulp.dest(paths.styles.dest));
 }
 
-// Minify and copy all JavaScript (except vendor scripts)
-// with sourcemaps all the way down
 function scripts() {
-  return gulp.src(paths.scripts)
-    .pipe(sourcemaps.init())
-      .pipe(coffee())
-      .pipe(uglify())
-      .pipe(concat('all.min.js'))
-    .pipe(sourcemaps.write())
-    .pipe(gulp.dest('build/js'));
+  return gulp.src(paths.scripts.src)
+    .pipe(uglify())
+    .pipe(concat(main.min.js))
+    .pipe(gulp.dest(paths.scripts.dest));
 }
 
-// Rerun the task when a file changes
 function watch() {
-  gulp.watch(paths.scripts, scripts);
-  gulp.watch(paths.images, images);
+  gulp.watch(paths.scripts.src, scripts);
+  gulp.watch(paths.styles.src, styles);
 }
+
+gulp.task(clean);
+gulp.task(watch);
+
+gulp.task('build',
+  gulp.series(clean),
+  gulp.parallel(styles, scripts));
+
+gulp.task('default',
+  gulp.series('build'))
 ```
 
 ## Incremental Builds

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var paths = {
 function clean() {
   // You can use multiple globbing patterns as you would with `gulp.src`,
   // for example if you are using del 2.0 or above, return its promise
-  del([ 'assets' ]);
+  return del([ 'assets' ]);
 }
 
 /* 
@@ -139,7 +139,7 @@ const paths = {
 };
 
 function clean() {
-  del([ 'assets' ]);
+  return del([ 'assets' ]);
 }
 
 function styles() {

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ var gulp = require('gulp');
 var rename = require('gulp-rename');
 var less = require('gulp-less');
 var cssmin = require('gulp-cssmin');
+var coffee = require('gulp-coffee');
 var concat = require('gulp-concat');
 var uglify = require('gulp-uglify');
 var del = require('del');
@@ -37,7 +38,7 @@ var paths = {
     dest: 'assets/styles/'
   },
   scripts: {
-    src: 'src/scripts/**/*.js',
+    src: 'src/scripts/**/*.coffee',
     dest: 'assets/scripts/'
   }
 };
@@ -68,7 +69,8 @@ function styles() {
 }
 
 function scripts() {
-  return gulp.src(paths.scripts.src)
+  return gulp.src(paths.scripts.src, { sourcemaps: true })
+    .pipe(coffee())
     .pipe(uglify())
     .pipe(concat('main.min.js'))
     .pipe(gulp.dest(paths.scripts.dest));
@@ -120,6 +122,7 @@ import gulp from 'gulp';
 import rename from 'gulp-rename';
 import less from 'gulp-less';
 import cssmin from 'gulp-cssmin';
+import coffee from 'gulp-coffee';
 import concat from 'gulp-concat';
 import uglify from 'gulp-uglify';
 import del from 'del';
@@ -130,7 +133,7 @@ const paths = {
     dest: 'assets/styles/'
   },
   scripts: {
-    src: 'src/scripts/**/*.js',
+    src: 'src/scripts/**/*.coffee',
     dest: 'assets/scripts/'
   }
 };
@@ -151,7 +154,8 @@ function styles() {
 }
 
 function scripts() {
-  return gulp.src(paths.scripts.src)
+  return gulp.src(paths.scripts.src, { sourcemaps: true })
+    .pipe(coffee())
     .pipe(uglify())
     .pipe(concat('main.min.js'))
     .pipe(gulp.dest(paths.scripts.dest));

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ var paths = {
  * and you can use all packages available on npm, but it must return either a
  * Promise, a Stream or take a callback and call it
  */
-function clean() {
+export.clean = function clean() {
   // You can use multiple globbing patterns as you would with `gulp.src`,
   // for example if you are using del 2.0 or above, return its promise
   return del([ 'assets' ]);
@@ -56,7 +56,7 @@ function clean() {
 /* 
  * Define our tasks using plain functions
  */
-function styles() {
+export.styles = function styles() {
   return gulp.src(paths.styles.src)
     .pipe(less())
     .pipe(cssmin())
@@ -68,7 +68,10 @@ function styles() {
     .pipe(gulp.dest(paths.styles.dest));
 }
 
-function scripts() {
+/*
+ * You can use CommonJS module notation to declare tasks
+ */
+export.scripts = function scripts() {
   return gulp.src(paths.scripts.src, { sourcemaps: true })
     .pipe(coffee())
     .pipe(uglify())
@@ -76,25 +79,19 @@ function scripts() {
     .pipe(gulp.dest(paths.scripts.dest));
 }
 
-function watch() {
+export.watch = function watch() {
   gulp.watch(paths.scripts.src, scripts);
   gulp.watch(paths.styles.src, styles);
 }
 
 /* 
- * Register some tasks to expose to the cli
- */
-gulp.task(clean);
-gulp.task(watch);
-
-/* 
- * Notice that you can specify if tasks can run in parallel or not
- * using `gulp.series` and `gulp.parallel`
+ * You can still use gulp.task to expose tasks and specify if tasks
+ * can run in parallel or not using `gulp.series` and `gulp.parallel`
  */
 gulp.task('build', gulp.series(clean, gulp.parallel(styles, scripts)));
 
 /*
- * Expose default task that can be called by just running `gulp` from cli
+ * Define default task that can be called by just running `gulp` from cli
  */
 gulp.task('default', build);
 ```
@@ -142,7 +139,15 @@ function clean() {
   return del([ 'assets' ]);
 }
 
-function styles() {
+/*
+ * For small tasks you can use arrow functions and export
+ */
+export () => del([ 'assets' ]) as clean;
+
+/*
+ * You can still declare named functions and export them as tasks
+ */
+export function styles() {
   return gulp.src(paths.styles.src)
     .pipe(less())
     .pipe(cssmin())
@@ -153,7 +158,7 @@ function styles() {
     .pipe(gulp.dest(paths.styles.dest));
 }
 
-function scripts() {
+export function scripts() {
   return gulp.src(paths.scripts.src, { sourcemaps: true })
     .pipe(coffee())
     .pipe(uglify())
@@ -161,13 +166,10 @@ function scripts() {
     .pipe(gulp.dest(paths.scripts.dest));
 }
 
-function watch() {
+export function watch() {
   gulp.watch(paths.scripts.src, scripts);
   gulp.watch(paths.styles.src, styles);
 }
-
-gulp.task(clean);
-gulp.task(watch);
 
 gulp.task('build', gulp.series(clean, gulp.parallel(styles, scripts)));
 


### PR DESCRIPTION
I added a new gulpfile sample from gulp 4.0 branch, more simple for new developers, who may not know about sourcemaps or coffee script, in my opinion and a version of it using **ES2015** with side notes about Babel installation requirement. [ issue  #1550 ]

_split view recommended_