### PR TITLE
Log require fail reason

### DIFF
--- a/bin/gulp.js
+++ b/bin/gulp.js
@@ -53,8 +53,9 @@ cli.on('require', function(name) {
   gutil.log('Requiring external module', chalk.magenta(name));
 });
 
-cli.on('requireFail', function(name) {
+cli.on('requireFail', function(name, error) {
   gutil.log(chalk.red('Failed to load external module'), chalk.magenta(name));
+  gutil.log(error.message);
 });
 
 cli.on('respawn', function(flags, child) {


### PR DESCRIPTION
Currently, requiring modules like `ts-node/register` can fail for unrelated issues (invalid `tsconfig.json`, no `typescript` installed, etc). It would be helpful for debugging to log out the reason it failed.

Related to https://github.com/TypeStrong/ts-node/issues/26.

It is possible to change the error level to `error.stack` instead, but the message is probably enough most of the time. Also, it may make sense to log it as part of the same log message - not sure what the etiquette is there.