### PR TITLE
add debounce feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var util = require('util');
 var Undertaker = require('undertaker');
 var vfs = require('vinyl-fs');
 var chokidar = require('chokidar');
+var debounce = require('debounce');
 
 function Gulp() {
   Undertaker.call(this);
@@ -44,6 +45,10 @@ Gulp.prototype.watch = function(glob, opt, task) {
 
   if (opt.ignoreInitial == null) {
     opt.ignoreInitial = true;
+  }
+
+  if (typeof opt.wait === 'number') {
+    fn = debounce(fn, opt.wait);
   }
 
   var watcher = chokidar.watch(glob, opt);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "man": "gulp.1",
   "dependencies": {
     "chokidar": "^1.2.0",
+    "debounce": "^1.0.0",
     "gulp-cli": "^1.0.0",
     "undertaker": "^0.15.0",
     "vinyl-fs": "^2.0.0"


### PR DESCRIPTION
#1304 

need `opt.wait` option for debounce in watch function
because, `fn` is wrapped `gulp.parallell`
so we cant use like this.

```js
gulp.watch(glob, debounce(gulp.series(scripts, unitTests), 200));
```

(https://github.com/gulpjs/gulp/blob/4.0/index.js#L42)

```js
  if (typeof task === 'function') {
    fn = this.parallel(task);
  }
```
 

or no wrap `fn` `gulp.parallell`
