### PR TITLE
Use gulp-cli in Getting Started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,8 +2,11 @@
 
 #### 1. Install gulp globally:
 
+__If you have previously installed a version of gulp globally, please run `npm rm --global gulp`
+to make sure your old version doesn't collide with gulp-cli.__
+
 ```sh
-$ npm install --global gulp
+$ npm install --global gulp-cli
 ```
 
 #### 2. Install gulp in your project devDependencies:


### PR DESCRIPTION
I've noticed this part is outdated, so I took this change from `master`.