### PR TITLE
3.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^2.4.3"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp",
   "description": "The streaming build system",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "homepage": "http://gulpjs.com",
   "repository": "gulpjs/gulp",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",


### PR DESCRIPTION
So, the vinyl-fs dependency is behind the times quite a bit. I haven't had time to test this, but this would potentially remove the warnings of many npm gulp users...