### PR TITLE
correct gulp.task signature

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -3,7 +3,7 @@
 Jump to:
   [gulp.src](#gulpsrcglobs-options) |
   [gulp.dest](#gulpdestpath-options) |
-  [gulp.task](#gulptaskname--deps-fn) |
+  [gulp.task](#gulptaskname--deps--fn) |
   [gulp.watch](#gulpwatchglob--opts-tasks-or-gulpwatchglob--opts-cb)
 
 ### gulp.src(globs[, options])

--- a/docs/API.md
+++ b/docs/API.md
@@ -108,7 +108,7 @@ Default: `0777`
 
 Octal permission string specifying mode for any folders that need to be created for output folder.
 
-### gulp.task(name [, deps, fn])
+### gulp.task(name [, deps] [, fn])
 
 Define a task using [Orchestrator].
 


### PR DESCRIPTION
`gulp.task(name [, deps, fn])` means that only `gulp.task(name, deps, fn)` and `gulp.task(name)` are allowed, which is apparently not the case and it's a bit confusing. The correct notation, `gulp.task(name [, deps] [, fn])`, also permits for `gulp.task(name, deps)`, and `gulp.task(name, fn)`.