### PR TITLE
graceful-fs v3.0.0 related deprecation warning (node v6.x.x)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var Orchestrator = require('orchestrator');
 var gutil = require('gulp-util');
 var deprecated = require('deprecated');
 var vfs = require('vinyl-fs');
+var watch = require('glob-watcher');
 
 function Gulp() {
   Orchestrator.call(this);
@@ -32,12 +33,12 @@ Gulp.prototype.watch = function(glob, opt, fn) {
 
   // Array of tasks given
   if (Array.isArray(fn)) {
-    return vfs.watch(glob, opt, function() {
+    return watch(glob, opt, function() {
       this.start.apply(this, fn);
     }.bind(this));
   }
 
-  return vfs.watch(glob, opt, fn);
+  return watch(glob, opt, fn);
 };
 
 // Let people use this class from our instance

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "archy": "^1.0.0",
     "chalk": "^1.0.0",
     "deprecated": "^0.0.1",
+    "glob-watcher": "^3.0.0",
     "gulp-util": "^3.0.0",
     "interpret": "^1.0.0",
     "liftoff": "^2.1.0",
@@ -38,13 +39,13 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^2.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",
     "eslint": "^1.7.3",
     "eslint-config-gulp": "^2.0.0",
-    "graceful-fs": "^3.0.0",
+    "graceful-fs": "^4.0.0",
     "istanbul": "^0.3.0",
     "jscs": "^2.3.5",
     "jscs-preset-gulp": "^1.0.0",


### PR DESCRIPTION
Hi,

when using gulp 3.9.1 with shell autocompletion, node v6.x.x reports deprecation message related to graceful-fs v3.0.0 (on each autocompletion):

`gulp (node:36477) fs: re-evaluating native module sources is not supported. If you are using the graceful-fs module, please update it to a more recent version.`

In order to do the update in the current gulp version, packages using old graceful-fs need to be replaced or updated. Upgrading to the latest vinyl-fs version implies 'back-porting' vfs.watch functionality.

This simple change will give gulp v3.x.x a little bit longer lease on life until v4.0.0. But the possible breaking change could be in the fact that change involves glob-watcher, which uses Chokidar in it's latest version and not all watch options are probably backward compatible. Not sure, how much that is an issue in practice. 

All best,
Uni