### PR TITLE
POC: Introduce Node.js 6+ compatibility mode for gulp@3

### DIFF
--- a/compat.js
+++ b/compat.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// Initialize vinyl-fs-wrap in Node.js 6+ compatibility mode
+var vfsWrap = require('./vinyl-fs-wrap');
+vfsWrap.initCompat();
+
+// Export the origial Gulp
+module.exports = require('./index');

--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ var util = require('util');
 var Orchestrator = require('orchestrator');
 var gutil = require('gulp-util');
 var deprecated = require('deprecated');
-var vfs = require('vinyl-fs');
+
+var vfsWrap = require('./vinyl-fs-wrap');
+vfsWrap.init();
+var vfs = vfsWrap.vfs;
 
 function Gulp() {
   Orchestrator.call(this);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^0.3.0",
+    "vinyl-fs-03-compat": "^0.3.15"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",

--- a/vinyl-fs-wrap.js
+++ b/vinyl-fs-wrap.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var compat = false;
+
+function init() {
+  if (exports.vfs) {
+    return;
+  }
+  exports.vfs = require('vinyl-fs');
+}
+
+function initCompat() {
+  if (exports.vfs) {
+    if (!compat) {
+      throw new Error(
+        'Gulp was already initialized without Node.js 6+ compatibility mode!\n' +
+        'Make sure that you require gulp/compat before other gulp plugins.\n' +
+        '\n' +
+        'Note that dependencies should not force this mode.\n' +
+        'The compatibility mode is intended only for the top-most gulpfile.js.\n'
+      );
+    }
+    return;
+  }
+  compat = true;
+  exports.vfs = require('vinyl-fs-03-compat');
+}
+
+exports.init = init;
+exports.initCompat = initCompat;


### PR DESCRIPTION
Refs: https://github.com/gulpjs/gulp/issues/1640#issuecomment-240683358

This is unfinished POC, it lacks the documentation and perhaps the tests.

It works though, and successfully unbreaks gulp@3 with Node.js 6+ if gulp was required using `require('gulp/compat')`.

This is a pure opt-in, it does not change anything unless the user specifically enables it (except for installing one extra unused package).

If gulp is already loaded at the time of the opt-in, then it throws an error —  so that deps won't misuse it and change the behaviour of everything, — this makes this option available only to the top-level gulpfile itself.

If this would be accepted, I will gladly move [vinyl-fs-03-compat](https://github.com/ChALkeR/vinyl-fs-03-compat) to gulpjs both on GitHub and npm.

/cc @phated, @contra, @TheAlphaNerd, @jasnell

Thoughts?