### PR TITLE
POC: Fallback to graceful-fs@4 if graceful-fs@3 is unsupported

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,13 @@ var util = require('util');
 var Orchestrator = require('orchestrator');
 var gutil = require('gulp-util');
 var deprecated = require('deprecated');
-var vfs = require('vinyl-fs');
+
+var vfs;
+try {
+  vfs = require('vinyl-fs');
+} catch (e) {
+  vfs = require('vinyl-fs-03-compat');
+}
 
 function Gulp() {
   Orchestrator.call(this);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^0.3.0",
+    "vinyl-fs-03-compat": "^0.3.15"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",


### PR DESCRIPTION
This uses a vinyl-fs@0.3 version coupled with graceful-fs@4 as a
fallback for the regular combination of vinyl-fs@0.3 and graceful-fs@3,
so that gulp@3 doesn't break on newer Node.js versions where
graceful-fs@3 is unsupported.

Current setups and Node.js versions (6.x and below) are not affected.

Alternative approach to #1760 