### PR TITLE
Vinyl-fs needs updating before node v7 is released.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^2.4.3"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",


### PR DESCRIPTION
Vinyl-fs must be updated to prevent it's dependency of graceful-fs from failing when node v7 is released. This PR updates the dependency vinyl-fs from ^0.3.0 to the current version (2.4.3).


When running `npm install gulp` npm issues the following warnings. All these warnings are due to Vinyl-fs being outdated.


```
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated lodash@1.0.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
```