### PR TITLE
Adds failing test for inheriting gulp.task from Orchestrator.add

### DIFF
--- a/test/tasks.js
+++ b/test/tasks.js
@@ -16,6 +16,19 @@ describe('gulp tasks', function() {
       gulp.reset();
       done();
     });
+    it('should set dep and fn defaults when only called with a name param', function(done) {
+      var noop, fn;
+      fn = function() {
+        return null;
+      };
+      noop = function() {};
+      gulp.task('test', ['a', 'b'], fn);
+      gulp.task('test');
+      gulp.tasks.test.fn.should.eql(noop);
+      gulp.tasks.test.dep.should.eql([]);
+      gulp.reset();
+      done();
+    });
   });
   describe('run()', function() {
     it('should run multiple tasks', function(done) {


### PR DESCRIPTION
On line 14 of `index.js`, the `task` method on Gulp's prototype is set to the `Gulp.prototype.add`, which is inherited from Orchestrator.

`14  Gulp.prototype.task = Gulp.prototype.add;`

This ensures that a call to Gulp's `task()` is a direct call to  Orchestrator's `add()`, and inheritance with Orchestrator's `task()` is no more. One effect of this is that a `task()` call with only a name param (and no dep or fn) will set the dep and fn properties of the task with the given name to default empty-ish values (i.e. empty array and noop)

However, this code is untested. Indeed, if line 14 is removed, all of Gulp's tests still pass. Because orchestrator's `task()` calls Orchestrator's `add()`, it is not immediately office why this line 14 is even necessary.

To avoid confusion in that matter and guard against regressions, this PR adds a test that fails if line 14 is removed. It does so by checking that only the default functionality of Orchestrator's `add()', and not Orchestrator's `task()', is executed when there is only one truthy param (the name param) passed to `gulp.task`