### PR TITLE
Use Object.assign. lodash.assign is deprecated.

### DIFF
--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -16,14 +16,13 @@ var source = require('vinyl-source-stream');
 var buffer = require('vinyl-buffer');
 var gutil = require('gulp-util');
 var sourcemaps = require('gulp-sourcemaps');
-var assign = require('lodash.assign');
 
 // add custom browserify options here
 var customOpts = {
   entries: ['./src/index.js'],
   debug: true
 };
-var opts = assign({}, watchify.args, customOpts);
+var opts = Object.assign({}, watchify.args, customOpts);
 var b = watchify(browserify(opts)); 
 
 // add transformations here


### PR DESCRIPTION
lodash.assign@4.2.0 has a deprecation notice. `Object.assign` is equivalent and removes a dependency.