### PR TITLE
Update to v4 of graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "coveralls": "^2.7.0",
     "eslint": "^1.7.3",
     "eslint-config-gulp": "^2.0.0",
-    "graceful-fs": "^3.0.0",
+    "graceful-fs": "^4.0.0",
     "istanbul": "^0.3.0",
     "jscs": "^2.3.5",
     "jscs-preset-gulp": "^1.0.0",


### PR DESCRIPTION
With v4, graceful-fs is no longer monkey patched. 
The old version of graceful-fs will also be deprecated when node >= 7 
Still there are several, much downloaded, packages around which has to update aswell. 

Lint and tests are good. 

[Ref v4](https://github.com/isaacs/node-graceful-fs#v4)