### PR TITLE
update vinyl-fs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^2.4.4"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",


### PR DESCRIPTION
Because version of vinyl-fs is too low.
Every time I do npm install gulp, gives me warning like below.
```
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
```