### PR TITLE
Let's update the installation command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ $ npm install --global gulp-cli
 #### 2. Install gulp in your project devDependencies:
 
 ```sh
-$ npm install --save-dev gulp
+$ npm install --save-dev 'gulpjs/gulp.git#4.0'
 ```
 
 #### 3. Create a `gulpfile.js` at the root of your project:


### PR DESCRIPTION
Let's update the installation with the correct command for v.4, applicable right now. When v.4 will be officially released, we can amend it accordingly. But for now, this is the correct installation command. Hopefully this will save people's time googling how to install.