### PR TITLE
Use gulp-babel & babel-preset-env to set up Gulp with Babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ gulp.task('default', build);
 Node already supports a lot of **ES2015**, to avoid compatibility problem we suggest to install Babel and rename your `gulpfile.js` as `gulpfile.babel.js`.
 
 ```sh
-npm install --save-dev babel-register babel-preset-es2015
+npm install --save-dev gulp-babel babel-preset-env
 ```
 
 Then create a **.babelrc** file with the preset configuration.
 
 ```js
 {
-  "presets": [ "es2015" ]
+  "presets": [ "env" ]
 }
 ```
 


### PR DESCRIPTION
Hi, I think we might need to update README about how to use Gulp with Babel. From the latest [Babel docs](https://babeljs.io/docs/setup/), we can just need to install `gulp-babel` and `babel-preset-env`. So I made a PR to represent this update. Hope someone could take some time to help and look into this. Thanks. 