### PR TITLE
bump version of vinyl-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^2.4.3"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",


### PR DESCRIPTION
current version specified has a security vulnerability in a dependency, upgrading version should resolve the issue.