### PR TITLE
Fixes update event

### DIFF
--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -30,7 +30,9 @@ var b = watchify(browserify(opts));
 // i.e. b.transform(coffeeify);
 
 gulp.task('js', bundle); // so you can run `gulp js` to build the file
-b.on('update', bundle); // on any dep update, runs the bundler
+b.on('update', function() {
+  return bundle();
+}); // on any dep update, runs the bundler
 b.on('log', gutil.log); // output build logs to terminal
 
 function bundle() {


### PR DESCRIPTION
In order for watchify to work correctly it requires for the function to be implicitly returned.

This took a while for me to figure out, but can confirm that the change works on watchify 3.9.0