### PR TITLE
update vinyl-fs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^2.4.4"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",


### PR DESCRIPTION
Currently the package.json dependency version is `"^0.3.0"` which results in downloading `vinyl-fs@0.3.14` which is many versions and years old now.