### PR TITLE
Bump vinyl-fs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "semver": "^4.1.0",
     "tildify": "^1.0.0",
     "v8flags": "^2.0.2",
-    "vinyl-fs": "^0.3.0"
+    "vinyl-fs": "^2.4.4"
   },
   "devDependencies": {
     "coveralls": "^2.7.0",


### PR DESCRIPTION
When running `npm install` whilst having `gulp: '3.9.1'` (latest version) referred in `package.json` I've seen the notice from NPM:

```
npm WARN deprecated graceful-fs@2.0.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
```

Then I've checked the `vinyl-fs` version on NPM registry and found out its latest version is `2.4.4`, but Gulp requires `^0.3.0`. The latest `vinyl-fs` version relies on the `graceful-fs: '^4.0.0'`, which should prevent any sudden failures.

Given that, I'd like to see the newer version required by Gulp to prevent any accidental build failures on Node >= 7.0.