### PR TITLE
Paraquire - paranoidal require

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var Orchestrator = paraquire('orchestrator', {
   builtin: ['events', 'util'], process: ['hrtime'],
 });
 var gutil = require('gulp-util');
-var deprecated = require('deprecated');
+var deprecated = paraquire('deprecated');
 var vfs = require('vinyl-fs');
 
 function Gulp() {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 'use strict';
+var paraquire = require('paraquire')(module);
 
 var util = require('util');
-var Orchestrator = require('orchestrator');
+var Orchestrator = paraquire('orchestrator', {
+  builtin: ['events', 'util'], process: ['hrtime'],
+});
 var gutil = require('gulp-util');
 var deprecated = require('deprecated');
 var vfs = require('vinyl-fs');

--- a/index.js
+++ b/index.js
@@ -5,7 +5,12 @@ var util = require('util');
 var Orchestrator = paraquire('orchestrator', {
   builtin: ['events', 'util'], process: ['hrtime'],
 });
-var gutil = require('gulp-util');
+var gutil = paraquire('gulp-util', {
+  builtin: ['buffer', 'events', 'stream', 'util'],
+  globalsSafe: true,
+  process: ['argv', 'browser', 'platform', 'stdout', 'version'],
+  'process.env': ['COLORTERM', 'FORCE_COLOR', 'TERM'],
+});
 var deprecated = paraquire('deprecated');
 var vfs = require('vinyl-fs');
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "liftoff": "^2.1.0",
     "minimist": "^1.1.0",
     "orchestrator": "^0.3.0",
+    "paraquire": "^1.0.0",
     "pretty-hrtime": "^1.0.0",
     "semver": "^4.1.0",
     "tildify": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "liftoff": "^2.1.0",
     "minimist": "^1.1.0",
     "orchestrator": "^0.3.0",
-    "paraquire": "^1.0.0",
+    "paraquire": "^1.2.0",
     "pretty-hrtime": "^1.0.0",
     "semver": "^4.1.0",
     "tildify": "^1.0.0",


### PR DESCRIPTION
I'm at hard work on [`paraquire`](https://github.com/nickkolok/paraquire) - security-oriented `require` alternative and I invite you to join.
This PR adds security jails to most libraries used in `gulp`; unfortunately, I haven't managed to give correct permissions to `vinyl-fs`, so it remains usually `require`d.

Should I prepare same PR to 4.0 branch?