### PR TITLE
Docs: Add missing callback calls in code example

### DIFF
--- a/docs/writing-a-plugin/README.md
+++ b/docs/writing-a-plugin/README.md
@@ -141,6 +141,7 @@ module.exports = function() {
         if (file.isStream()) {
             // file.contents is a Stream - https://nodejs.org/api/stream.html
             this.emit('error', new PluginError(PLUGIN_NAME, 'Streams not supported!'));
+            callback();
 
             // or, if you can handle Streams:
             //file.contents = file.contents.pipe(...
@@ -148,6 +149,7 @@ module.exports = function() {
         } else if (file.isBuffer()) {
             // file.contents is a Buffer - https://nodejs.org/api/buffer.html
             this.emit('error', new PluginError(PLUGIN_NAME, 'Buffers not supported!'));
+            callback();
 
             // or, if you can handle Buffers:
             //file.contents = ...


### PR DESCRIPTION
Gulp pipeline does not work as expected when callback call is missing, e.g. tasks even when `gulp-plumber` is used, immediately stop when errors occur.
This pull request adds the missing callback calls in the code example of the "Writing a plugin" documentation.
