### PR TITLE
docs(recipe): Running gulp via cron task

### DIFF
--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -26,3 +26,4 @@
 * [Run Grunt Tasks from Gulp](run-grunt-tasks-from-gulp.md)
 * [Exports as tasks](exports-as-tasks.md)
 * [Rollup with rollup-stream](rollup-with-rollup-stream.md)
+* [Run gulp task via cron job](cron-task.md)

--- a/docs/recipes/cron-task.md
+++ b/docs/recipes/cron-task.md
@@ -1,0 +1,25 @@
+# Run gulp task via cron job
+
+While logged in via a user that has privileges to run `gulp`, run the following:
+
+    crontab -e
+    
+to edit your current "[crontab](https://en.wikipedia.org/wiki/Cron)" file.
+
+Typically, within a cron job, you want to run any binary using absolute paths,
+so an initial approach to running `gulp build` every minute might look like:
+
+    * * * * * cd /your/dir/to/run/in && /usr/local/bin/gulp build
+
+However, you might see in the cron logs that you get this error:
+
+> `/usr/bin/env: node: No such file or directory`
+
+To fix this, we need to add a [symbolic link](https://en.wikipedia.org/wiki/Ln_\(Unix\))
+within `/usr/bin` to point to the actual path of our node binary.
+
+Be sure you are logged in as a **sudo** user, and paste in the following command to your terminal:
+
+    sudo ln -s $(which node) /usr/bin/node
+
+Once this link is established, your cron task should run successfully.


### PR DESCRIPTION
The main point of this is to provide documentation
when you get the following error in the cron logs
after trying to run a gulp task:

> /usr/bin/env: node: No such file or directory

Resolves #2033.