### PR TITLE
chore: update graceful-fs to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "coveralls": "^2.7.0",
     "eslint": "^1.7.3",
     "eslint-config-gulp": "^2.0.0",
-    "graceful-fs": "^3.0.0",
+    "graceful-fs": "^4.0.0",
     "istanbul": "^0.3.0",
     "jscs": "^2.3.5",
     "jscs-preset-gulp": "^1.0.0",


### PR DESCRIPTION
Test suite is broken on Node master with graceful-fs 3.x