### PR TITLE
chore: remove graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "coveralls": "^2.7.0",
     "eslint": "^1.7.3",
     "eslint-config-gulp": "^2.0.0",
-    "graceful-fs": "^3.0.0",
     "istanbul": "^0.3.0",
     "jscs": "^2.3.5",
     "jscs-preset-gulp": "^1.0.0",

--- a/test/dest.js
+++ b/test/dest.js
@@ -4,7 +4,7 @@ var gulp = require('../');
 var should = require('should');
 var join = require('path').join;
 var rimraf = require('rimraf');
-var fs = require('graceful-fs');
+var fs = require('fs');
 
 require('mocha');
 

--- a/test/watch.js
+++ b/test/watch.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var gulp = require('../');
-var fs = require('graceful-fs');
+var fs = require('fs');
 var rimraf = require('rimraf');
 var mkdirp = require('mkdirp');
 var path = require('path');


### PR DESCRIPTION
This is an alternative to #2056 that removes the use of graceful-fs
in the test suite

AFAICT there are no other uses of graceful-fs in gulp proper. We may want to do similar digging into vinyl-fs