### PR TITLE
Refactoring of code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var util = require('util');
-var Orchestrator = require('orchestrator');
-var gutil = require('gulp-util');
-var deprecated = require('deprecated');
-var vfs = require('vinyl-fs');
+var util = require('util'),
+    Orchestrator = require('orchestrator'),
+    gutil = require('gulp-util'),
+    deprecated = require('deprecated'),
+    vfs = require('vinyl-fs');
 
 function Gulp() {
   Orchestrator.call(this);


### PR DESCRIPTION
Here, I have removed 'var' keyword since we can use only one to define different variables and this will also utilize our memory and load time.