### PR TITLE
Update Github links for browserify in docs

### DIFF
--- a/docs/recipes/browserify-transforms.md
+++ b/docs/recipes/browserify-transforms.md
@@ -1,6 +1,6 @@
 # Browserify + Transforms
 
-[Browserify](https://github.com/substack/node-browserify) has become an important and indispensable
+[Browserify](https://github.com/browserify/browserify) has become an important and indispensable
 tool but requires being wrapped before working well with gulp. Below is a simple recipe for using
 Browserify with transforms.
 

--- a/docs/recipes/browserify-uglify-sourcemap.md
+++ b/docs/recipes/browserify-uglify-sourcemap.md
@@ -1,6 +1,6 @@
 # Browserify + Uglify2 with sourcemaps
 
-[Browserify](https://github.com/substack/node-browserify) has become an important and indispensable
+[Browserify](https://github.com/browserify/browserify) has become an important and indispensable
 tool but requires being wrapped before working well with gulp. Below is a simple recipe for using
 Browserify with full sourcemaps that resolve to the original individual files.
 

--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -1,8 +1,8 @@
 # Fast browserify builds with watchify
 
-As a [browserify](https://github.com/substack/node-browserify) project begins to expand, the time to bundle it slowly gets longer and longer. While it might start at 1 second, it's possible to be waiting 30 seconds for your project to build on particularly large projects.
+As a [browserify](https://github.com/browserify/browserify) project begins to expand, the time to bundle it slowly gets longer and longer. While it might start at 1 second, it's possible to be waiting 30 seconds for your project to build on particularly large projects.
 
-That's why [substack](https://github.com/substack) wrote [watchify](https://github.com/substack/watchify), a persistent browserify bundler that watches files for changes and *only rebuilds what it needs to*. This way, that first build might still take 30 seconds, but subsequent builds can still run in under 100ms – which is a huge improvement.
+That's why [substack](https://github.com/substack) wrote [watchify](https://github.com/browserify/watchify), a persistent browserify bundler that watches files for changes and *only rebuilds what it needs to*. This way, that first build might still take 30 seconds, but subsequent builds can still run in under 100ms – which is a huge improvement.
 
 Watchify doesn't have a gulp plugin, and it doesn't need one: you can use [vinyl-source-stream](https://github.com/hughsk/vinyl-source-stream) to pipe the bundle stream into your gulp pipeline.
 


### PR DESCRIPTION
Changed old link:
http://github.com/substack/node-browserify -> https://github.com/browserify/browserify
Changed old link:
http://github.com/substack/watchify -> https://github.com/browserify/watchify