### PR TITLE
Docs: Fix problem about the use of gulplog

### DIFF
--- a/docs/recipes/fast-browserify-builds-with-watchify.md
+++ b/docs/recipes/fast-browserify-builds-with-watchify.md
@@ -31,7 +31,7 @@ var b = watchify(browserify(opts));
 
 gulp.task('js', bundle); // so you can run `gulp js` to build the file
 b.on('update', bundle); // on any dep update, runs the bundler
-b.on('log', log.info); // output build logs to terminal
+b.on('log', log.info.bind(log)); // output build logs to terminal
 
 function bundle() {
   return b.bundle()


### PR DESCRIPTION
The function(log.info) needs to bind 'log' so that it can emit 'info' event correctly, otherwise, an error 'this'(maybe the instance of Browserify) will be used by the function(log.info).