### PR TITLE
Fix error in ES2015 usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ export { watchFiles as watch };
  * You can still use `gulp.task`
  * for example to set task names that would otherwise be invalid
  */
-const clean = gulp.series(clean, gulp.parallel(styles, scripts));
-gulp.task('clean', clean);
+const build = gulp.series(clean, gulp.parallel(styles, scripts));
+gulp.task('build', build);
 
 /*
  * Export a default task


### PR DESCRIPTION
The task `clean` was defined twice and the `build` task was missing in
the ES2015 example.
This commit renames the second `clean` task to `build` to match the ES5
example.

Closes gulpjs/gulp#2099