### PR TITLE
Added notice for 4.0.0 vs 3.9.1 documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,3 +1,7 @@
+Note: these docs are for version v4.0.0 (aka `gulp@next`) If you're on gulp
+v3.9.1, which is the current standard `npm` release, you probably want [that
+version's documentation](https://github.com/gulpjs/gulp/blob/v3.9.1/docs/API.md).
+
 ## gulp API docs
 
 * [gulp.src](#gulpsrcglobs-options) - Emit files matching one or more globs


### PR DESCRIPTION
Because the master branch is the authoritative source of documentation, it can be confusing for developers who have used `npm install gulp` (or joined a project using gulp 3) that the master branch is for a different major release. This PR adds a simple notification to the API docs, which are linked to from https://gulpjs.com/, that the standard version installed by `npm install gulp`.

It's worth noting that, while it might be obvious to people familiar with gulp's development, there's no indication that there's a mismatch between master and the current node release anywhere on `https://gulpjs.com/`, nor on `master:docs/API.md`, nor in any of the top google search results for "gulpjs documentation".