### PR TITLE
Fix recipe - Templating with Swig and YAML front-matter

### DIFF
--- a/docs/recipes/templating-with-swig-and-yaml-front-matter.md
+++ b/docs/recipes/templating-with-swig-and-yaml-front-matter.md
@@ -34,7 +34,7 @@ var frontMatter = require('gulp-front-matter');
 gulp.task('compile-page', function() {
   gulp.src('page.html')
       .pipe(frontMatter({ property: 'data' }))
-      .pipe(swig())
+      .pipe(swig({ defaults: { cache: false } }))
       .pipe(gulp.dest('build'));
 });
 


### PR DESCRIPTION
I followed this recipe and was experiencing an issue where livereload was not showing the changes I made to the watched html file. I checked the gulp-swig documentation and disabling caching fixed the issue.