### PR TITLE
fix: typo in code in recipe for running tasks in folders

### DIFF
--- a/docs/recipes/running-task-steps-per-folder.md
+++ b/docs/recipes/running-task-steps-per-folder.md
@@ -38,7 +38,7 @@ function getFolders(dir) {
 
 gulp.task('scripts', function(done) {
    var folders = getFolders(scriptsPath);
-   if (folder.length === 0) return done(); // nothing to do!
+   if (folders.length === 0) return done(); // nothing to do!
    var tasks = folders.map(function(folder) {
       return gulp.src(path.join(scriptsPath, folder, '/**/*.js'))
         // concat into foldername.js


### PR DESCRIPTION
Just corrected the variable name to ```folders``` in the folder recipe.