### PR TITLE
Clarify gulpfile.babel.js example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,15 @@ function watchFiles() {
 export { watchFiles as watch };
 
 /*
+ * Specify if tasks run in series or parallel using `gulp.series` and `gulp.parallel`
+ */
+const build = gulp.series(clean, gulp.parallel(styles, scripts));
+
+/*
  * You can still use `gulp.task`
  * for example to set task names that would otherwise be invalid
  */
-const clean = gulp.series(clean, gulp.parallel(styles, scripts));
-gulp.task('clean', clean);
+gulp.task('build', build);
 
 /*
  * Export a default task


### PR DESCRIPTION
This PR updates the README example to achieve parity with the `require` syntax example and contain error-free code.

**Background**
When following the code example for creating a `gulpfile.babel.js`, I noticed that there was some funkiness in these lines. Specifically, it would actually throw an error due to redefining `const clean`. Hopefully this clears that up and makes the documentation easier to follow for users.

Feedback welcome 😃 