### PR TITLE
Explicitly run coveralls step

### DIFF
--- a/.ci/.azure-pipelines-steps.yml
+++ b/.ci/.azure-pipelines-steps.yml
@@ -1,0 +1,30 @@
+steps:
+- script: npm i -g npm@$(npm_version)
+  displayName: Use legacy npm version $(npm_version)
+  condition: ne(variables['npm_version'], '')
+
+- task: NodeTool@0
+  inputs:
+    versionSpec: '$(node_version)'
+  displayName: Use Node $(node_version)
+
+- script: npm install
+  displayName: npm install
+
+- script: npm run coveralls
+  env:
+    COVERALLS_REPO_TOKEN: $(COVERALLS_REPO_TOKEN_SECRET)
+  displayName: Run coveralls
+  condition: eq(variables['run_coveralls'], true)
+
+- script: npm test
+  displayName: Run tests
+  condition: ne(variables['run_coveralls'], true)
+
+- script: npm run azure-pipelines
+  displayName: Write tests to xml
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: '**/test.xunit'
+  condition: succeededOrFailed()

--- a/.ci/.azure-pipelines-steps.yml
+++ b/.ci/.azure-pipelines-steps.yml
@@ -11,7 +11,7 @@ steps:
 - script: npm install
   displayName: npm install
 
-- script: npm run cover && istanbul-coveralls
+- script: istanbul cover _mocha --report lcovonly && istanbul-coveralls
   env:
     COVERALLS_REPO_TOKEN: $(COVERALLS_REPO_TOKEN_SECRET)
   displayName: Run coveralls

--- a/.ci/.azure-pipelines-steps.yml
+++ b/.ci/.azure-pipelines-steps.yml
@@ -11,7 +11,7 @@ steps:
 - script: npm install
   displayName: npm install
 
-- script: npm run coveralls
+- script: npm run cover && istanbul-coveralls
   env:
     COVERALLS_REPO_TOKEN: $(COVERALLS_REPO_TOKEN_SECRET)
   displayName: Run coveralls

--- a/.ci/.azure-pipelines.yml
+++ b/.ci/.azure-pipelines.yml
@@ -1,0 +1,72 @@
+trigger:
+- master
+- releases/*
+
+jobs:
+  - job: Test_Linux
+    displayName: Run Tests on Linux
+    pool:
+      vmImage: "Ubuntu 16.04"
+    variables:
+      run_coveralls: true
+    strategy:
+      matrix:
+        Node_v10:
+          node_version: 10
+        Node_v8:
+          node_version: 8
+        Node_v6:
+          node_version: 6
+        Node_v4:
+          node_version: 4
+        Node_v0_12:
+          node_version: 0.12
+        Node_v0_10:
+          node_version: 0.10
+    steps:
+      - template: .azure-pipelines-steps.yml
+
+  - job: Test_Windows
+    displayName: Run Tests on Windows
+    pool:
+      vmImage: vs2017-win2016
+    strategy:
+      matrix:
+        Node_v10:
+          node_version: 10
+        Node_v8:
+          node_version: 8
+        Node_v6:
+          node_version: 6
+        Node_v4:
+          node_version: 4
+          npm_version: 2
+        Node_v0_12:
+          node_version: 0.12
+          npm_version: 2
+        Node_v0_10: 
+          node_version: 0.10
+          npm_version: 2
+    steps:
+      - template: .azure-pipelines-steps.yml
+
+  - job: Test_MacOS
+    displayName: Run Tests on MacOS
+    pool:
+      vmImage: macos-10.13
+    strategy:
+      matrix:
+        Node_v10:
+          node_version: 10
+        Node_v8:
+          node_version: 8
+        Node_v6:
+          node_version: 6
+        Node_v4:
+          node_version: 4
+        Node_v0_12:
+          node_version: 0.12
+        Node_v0_10:
+          node_version: 0.10
+    steps:
+      - template: .azure-pipelines-steps.yml

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 
 # Garbage files
 .DS_Store
+
+# Test results
+xunit.xml

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "mocha --async-only",
+    "azure-pipelines": "mocha --async-only --reporter xunit -O output=test.xunit",
     "cover": "istanbul cover _mocha --report lcovonly",
     "coveralls": "npm run cover && istanbul-coveralls"
   },


### PR DESCRIPTION
This will allow the token to be passed on PRs in without concern of it being stolen by a changed script. Without this, an attacker could change the `npm run coveralls` command in package.json in their PR so that it does something bad (e.g. sends them the token).

See https://github.com/gulpjs/gulp/pull/2299#issuecomment-475003985