### PR TITLE
Typo in last line of usage example

### DIFF
--- a/docs/api/vinyl.md
+++ b/docs/api/vinyl.md
@@ -40,7 +40,7 @@ file.stem = 'foo';
 file.path === '/specs/foo.txt';
 file.extname === '.txt';
 file.extname = '.js';
-file.path === '/specs/file.js';
+file.path === '/specs/foo.js';
 ```
 
 ## Signature


### PR DESCRIPTION
After changing the stem to foo and the ext to .js, the full path should be `/specs/foo.js`