### PR TITLE
Added stream error handling

### DIFF
--- a/docs/recipes/browserify-multiple-destination.md
+++ b/docs/recipes/browserify-multiple-destination.md
@@ -14,7 +14,7 @@ var buffer = require('gulp-buffer');
 var sourcemaps = require('gulp-sourcemaps');
 var uglify = require('gulp-uglify');
 
-gulp.task('js', function () {
+gulp.task('js', function (next) {
 
   return gulp.src('src/**/*.js', {read: false}) // no need of reading file because browserify does.
 
@@ -25,7 +25,12 @@ gulp.task('js', function () {
 
       // replace file contents with browserify's bundle stream
       file.contents = browserify(file.path, {debug: true}).bundle();
-
+      
+      // this will avoid crashing Gulp on unexpected tokens or other errors
+      file.contents.on('error', err => {
+        console.error(err);
+        next();
+      });
     }))
 
     // transform streaming contents into buffer contents (because gulp-sourcemaps does not support streaming contents)


### PR DESCRIPTION
Some errors, like unexpected tokens, cause the Gulp task to crash and this will avoid that.