### PR TITLE
Correct typo in rollup example

### DIFF
--- a/docs/getting-started/7-using-plugins.md
+++ b/docs/getting-started/7-using-plugins.md
@@ -37,7 +37,7 @@ const { rollup } = require('rollup');
 
 // Rollup's promise API works great in an `async` task
 exports.default = async function() {
-  const bundle = await rollup.rollup({
+  const bundle = await rollup({
     input: 'src/index.js'
   });
 


### PR DESCRIPTION
Rollup is imported by name, so it should be called like `rollup()`.