### PR TITLE
Fix for code example in documentation (Getting Started/Async Completion)

### DIFF
--- a/docs/getting-started/4-async-completion.md
+++ b/docs/getting-started/4-async-completion.md
@@ -127,7 +127,7 @@ When not using any of the previous options, you can define your task as an [`asy
 const fs = require('fs');
 
 async function asyncAwaitTask() {
-  const { version } = fs.readFileSync('package.json');
+  const { version } = JSON.parse(fs.readFileSync('package.json', 'utf8'));
   console.log(version);
   await Promise.resolve('some result');
 }


### PR DESCRIPTION
The code example on the [Async Completion](https://gulpjs.com/docs/en/getting-started/async-completion) page was meant to log the version from package.json to the console, but it was logging out "undefined".

Output of previous code example:
![image](https://user-images.githubusercontent.com/2593591/78204915-e07e0f00-7468-11ea-9817-d2228fd4af50.png)

Output of fixed code example:
![image](https://user-images.githubusercontent.com/2593591/78204885-ce03d580-7468-11ea-90c3-360498ee9451.png)

