### PR TITLE
Update rollup recipe

### DIFF
--- a/docs/recipes/rollup-with-rollup-stream.md
+++ b/docs/recipes/rollup-with-rollup-stream.md
@@ -24,7 +24,7 @@ gulp.task('rollup', function() {
 
 ## Usage with sourcemaps
 ```js
-// npm install --save-dev gulp rollup-stream gulp-sourcemaps vinyl-source-stream vinyl-buffer
+// npm install --save-dev gulp rollup-stream@ gulp-sourcemaps vinyl-source-stream vinyl-buffer
 // optional: npm install --save-dev gulp-rename
 var gulp = require('gulp');
 var rollup = require('rollup-stream');

--- a/docs/recipes/rollup-with-rollup-stream.md
+++ b/docs/recipes/rollup-with-rollup-stream.md
@@ -4,7 +4,7 @@ Like Browserify, [Rollup](https://rollupjs.org/) is a bundler and thus only fits
 
 ## Basic usage
 ```js
-// npm install --save-dev gulp rollup-stream vinyl-source-stream
+// npm install --save-dev gulp rollup-stream@1 vinyl-source-stream
 var gulp = require('gulp');
 var rollup = require('rollup-stream');
 var source = require('vinyl-source-stream');

--- a/docs/recipes/rollup-with-rollup-stream.md
+++ b/docs/recipes/rollup-with-rollup-stream.md
@@ -36,7 +36,8 @@ var buffer = require('vinyl-buffer');
 gulp.task('rollup', function() {
   return rollup({
       entry: './src/main.js',
-      sourceMap: true
+      sourceMap: true,
+      format: 'umd'
     })
 
     // point to the entry file.

--- a/docs/recipes/rollup-with-rollup-stream.md
+++ b/docs/recipes/rollup-with-rollup-stream.md
@@ -24,7 +24,7 @@ gulp.task('rollup', function() {
 
 ## Usage with sourcemaps
 ```js
-// npm install --save-dev gulp rollup-stream@ gulp-sourcemaps vinyl-source-stream vinyl-buffer
+// npm install --save-dev gulp rollup-stream@1 gulp-sourcemaps vinyl-source-stream vinyl-buffer
 // optional: npm install --save-dev gulp-rename
 var gulp = require('gulp');
 var rollup = require('rollup-stream');

--- a/docs/recipes/rollup-with-rollup-stream.md
+++ b/docs/recipes/rollup-with-rollup-stream.md
@@ -4,7 +4,7 @@ Like Browserify, [Rollup](https://rollupjs.org/) is a bundler and thus only fits
 
 ## Basic usage
 ```js
-// npm install --save-dev gulp rollup-stream@1 vinyl-source-stream
+// npm install --save-dev gulp @rollup/stream@1 vinyl-source-stream
 var gulp = require('gulp');
 var rollup = require('rollup-stream');
 var source = require('vinyl-source-stream');
@@ -24,7 +24,7 @@ gulp.task('rollup', function() {
 
 ## Usage with sourcemaps
 ```js
-// npm install --save-dev gulp rollup-stream@1 gulp-sourcemaps vinyl-source-stream vinyl-buffer
+// npm install --save-dev gulp @rollup/stream@1 gulp-sourcemaps vinyl-source-stream vinyl-buffer
 // optional: npm install --save-dev gulp-rename
 var gulp = require('gulp');
 var rollup = require('rollup-stream');

--- a/docs/recipes/rollup-with-rollup-stream.md
+++ b/docs/recipes/rollup-with-rollup-stream.md
@@ -11,7 +11,7 @@ var source = require('vinyl-source-stream');
 
 gulp.task('rollup', function() {
   return rollup({
-      entry: './src/main.js'
+      input: './src/main.js'
     })
 
     // give the file the name you want to output with
@@ -35,8 +35,8 @@ var buffer = require('vinyl-buffer');
 
 gulp.task('rollup', function() {
   return rollup({
-      entry: './src/main.js',
-      sourceMap: true,
+      input: './src/main.js',
+      sourcemap: true,
       format: 'umd'
     })
 


### PR DESCRIPTION
Just a couple of deprecated properties. Additionally, specifying format is mandatory now or rollup complains.