### PR TITLE
Removed the gulp-sourcemaps plugin

### DIFF
--- a/docs/recipes/browserify-transforms.md
+++ b/docs/recipes/browserify-transforms.md
@@ -15,7 +15,6 @@ var source = require('vinyl-source-stream');
 var buffer = require('vinyl-buffer');
 var log = require('gulplog');
 var uglify = require('gulp-uglify');
-var sourcemaps = require('gulp-sourcemaps');
 var reactify = require('reactify');
 
 gulp.task('javascript', function () {
@@ -28,13 +27,11 @@ gulp.task('javascript', function () {
   });
 
   return b.bundle()
-    .pipe(source('app.js'))
+    .pipe(source('app.js', { sourcemaps: true }))
     .pipe(buffer())
-    .pipe(sourcemaps.init({loadMaps: true}))
         // Add transformation tasks to the pipeline here.
         .pipe(uglify())
         .on('error', log.error)
-    .pipe(sourcemaps.write('./'))
-    .pipe(gulp.dest('./dist/js/'));
+    .pipe(gulp.dest('./dist/js/', { sourcemaps: '../sourcemaps/' }));
 });
 ```


### PR DESCRIPTION
The gulp-sourcemaps plugin can be removed.
Gulp already has built-in support for source maps.
https://gulpjs.com/docs/en/api/src/#sourcemaps