### PR TITLE
Revert "Docs: Remove gulp-sourcemaps because it is built-in (#2592)"

### DIFF
--- a/docs/recipes/browserify-transforms.md
+++ b/docs/recipes/browserify-transforms.md
@@ -15,6 +15,7 @@ var source = require('vinyl-source-stream');
 var buffer = require('vinyl-buffer');
 var log = require('gulplog');
 var uglify = require('gulp-uglify');
+var sourcemaps = require('gulp-sourcemaps');
 var reactify = require('reactify');
 
 gulp.task('javascript', function () {
@@ -27,11 +28,13 @@ gulp.task('javascript', function () {
   });
 
   return b.bundle()
-    .pipe(source('app.js', { sourcemaps: true }))
+    .pipe(source('app.js'))
     .pipe(buffer())
+    .pipe(sourcemaps.init({loadMaps: true}))
         // Add transformation tasks to the pipeline here.
         .pipe(uglify())
         .on('error', log.error)
-    .pipe(gulp.dest('./dist/js/', { sourcemaps: '../sourcemaps/' }));
+    .pipe(sourcemaps.write('./'))
+    .pipe(gulp.dest('./dist/js/'));
 });
 ```


### PR DESCRIPTION
This pull request reverts a previous change to the Browserify documentation relating to sourcemaps.

Unfortunately the previous change results in the following error:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Object
    at validateString (internal/validators.js:124:11)
    at Object.resolve (path.js:1039:7)
    at module.exports (node_modules/vinyl-source-stream/index.js:13:34)
```