### PR TITLE
Updated Invalid Link [Docs | Stream-Handbook]

### DIFF
--- a/docs/writing-a-plugin/README.md
+++ b/docs/writing-a-plugin/README.md
@@ -193,7 +193,7 @@ if (someCondition) {
 
 If you're unfamiliar with streams, you will need to read up on them:
 
-* https://www.npmjs.com/package/stream-handbook (a MUST read)
+* https://www.freecodecamp.org/news/node-js-streams-everything-you-need-to-know-c9141306be93/
 * https://nodejs.org/api/stream.html
 
 Other libraries that are not file manipulating through streams but are made for use with gulp are tagged with the [gulpfriendly](https://npmjs.org/browse/keyword/gulpfriendly) keyword on npm.

--- a/docs/writing-a-plugin/README.md
+++ b/docs/writing-a-plugin/README.md
@@ -193,7 +193,7 @@ if (someCondition) {
 
 If you're unfamiliar with streams, you will need to read up on them:
 
-* https://github.com/substack/stream-handbook (a MUST read)
+* https://www.npmjs.com/package/stream-handbook (a MUST read)
 * https://nodejs.org/api/stream.html
 
 Other libraries that are not file manipulating through streams but are made for use with gulp are tagged with the [gulpfriendly](https://npmjs.org/browse/keyword/gulpfriendly) keyword on npm.


### PR DESCRIPTION
Link referenced to stream-handbook is wrong 
This is my first public PR hope this link is correct.

Updated Link - https://www.npmjs.com/package/stream-handbook