### PR TITLE
Chore: Fix dependency vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
-    "glob-watcher": "^5.0.3",
-    "gulp-cli": "^2.2.0",
+    "glob-watcher": "6.0.0",
+    "gulp-cli": "file:../gulp-cli",
     "undertaker": "^1.2.1",
-    "vinyl-fs": "^3.0.0"
+    "vinyl-fs": "4.0.0"
   },
   "devDependencies": {
     "coveralls": "github:phated/node-coveralls#2.x",


### PR DESCRIPTION
These vulnerabilities were discovered through the Snyk tool: 

```λ snyk-win.exe test https://github.com/gulpjs/gulp

Testing https://github.com/gulpjs/gulp...

✗ Medium severity vulnerability found in glob-parent
  Description: Regular Expression Denial of Service (ReDoS)
  Info: https://security.snyk.io/vuln/SNYK-JS-GLOBPARENT-1016905
  Introduced through: glob-watcher@5.0.5, vinyl-fs@3.0.3
  From: glob-watcher@5.0.5 > chokidar@2.1.8 > glob-parent@3.1.0
  From: vinyl-fs@3.0.3 > glob-stream@6.1.0 > glob-parent@3.1.0

✗ High severity vulnerability found in unset-value
  Description: Prototype Pollution
  Info: https://security.snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660
  Introduced through: glob-watcher@5.0.5, gulp-cli@2.3.0
  From: glob-watcher@5.0.5 > chokidar@2.1.8 > braces@2.3.2 > snapdragon@0.8.2 > base@0.11.2 > cache-base@1.0.1 > unset-value@1.0.0
  From: glob-watcher@5.0.5 > anymatch@2.0.0 > micromatch@3.1.10 > snapdragon@0.8.2 > base@0.11.2 > cache-base@1.0.1 > unset-value@1.0.0
  From: gulp-cli@2.3.0 > matchdep@2.0.0 > micromatch@3.1.10 > snapdragon@0.8.2 > base@0.11.2 > cache-base@1.0.1 > unset-value@1.0.0
  and 28 more...

✗ High severity vulnerability found in ansi-regex
  Description: Regular Expression Denial of Service (ReDoS)
  Info: https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908
  Introduced through: gulp-cli@2.3.0
  From: gulp-cli@2.3.0 > yargs@7.1.2 > string-width@1.0.2 > strip-ansi@3.0.1 > ansi-regex@2.1.1
  From: gulp-cli@2.3.0 > yargs@7.1.2 > cliui@3.2.0 > strip-ansi@3.0.1 > ansi-regex@2.1.1
  From: gulp-cli@2.3.0 > yargs@7.1.2 > cliui@3.2.0 > string-width@1.0.2 > strip-ansi@3.0.1 > ansi-regex@2.1.1
  and 2 more...

```

- Fix is simple, just upgrade to slightly newer versions
- But requires my PR here as well https://github.com/gulpjs/gulp-cli/pull/244