### PR TITLE
Update README.md to use deleteAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ import concat from 'gulp-concat';
 import uglify from 'gulp-uglify';
 import rename from 'gulp-rename';
 import cleanCSS from 'gulp-clean-css';
-import del from 'del';
+import {deleteAsync} from 'del';
 
 const paths = {
   styles: {
@@ -140,7 +140,7 @@ const paths = {
 /*
  * For small tasks you can export arrow functions
  */
-export const clean = () => del([ 'assets' ]);
+export const clean = () => deleteAsync([ 'assets' ]);
 
 /*
  * You can also declare named functions and export them as tasks


### PR DESCRIPTION
For ~two years 'del' no longer exports a default method, and instead exports `deleteAsync()` and `deleteSync()`, the former replacing `del()`

See https://github.com/sindresorhus/del/commit/106d7d8ff813059c437d7c428539b7719292d1d6