### PR TITLE
CI: add Node versions 18, 20 and 22

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14, 16]
+        node: [10, 12, 14, 16, 18, 20, 22]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
The version matrix was missing all currently supported Node versions. Add them to run PR tests / lints with modern Node versions too.