### PR TITLE
Update 4-async-completion.md

### DIFF
--- a/docs/getting-started/4-async-completion.md
+++ b/docs/getting-started/4-async-completion.md
@@ -68,10 +68,10 @@ exports.default = childProcessTask;
 ### Returning an observable
 
 ```js
-const { Observable } = require('rxjs');
+const { of } = require('rxjs');
 
 function observableTask() {
-  return Observable.of(1, 2, 3);
+  return of(1, 2, 3);
 }
 
 exports.default = observableTask;


### PR DESCRIPTION
Starting with RxJS 6.x, the Observable.of method has been removed, and it's recommended to directly import the of function from 'rxjs' instead.