### PR TITLE
fix: Support top-level await on Node 22.12+

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "glob-watcher": "^6.0.0",
-    "gulp-cli": "^3.0.0",
+    "gulp-cli": "^3.1.0",
     "undertaker": "^2.0.0",
     "vinyl-fs": "^4.0.0"
   },


### PR DESCRIPTION
Upgrading gulp-cli to support top-level await in Node 22.12+

Since this version and newer started support `require(esm)`, a different error was thrown if a top-level await was encountered. We needed to add support in gulp-cli to support it.