### PR TITLE
fix: Avoid Node.js deprecation warning for `fs.Stats`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "glob-watcher": "^6.0.0",
     "gulp-cli": "^3.1.0",
     "undertaker": "^2.0.0",
-    "vinyl-fs": "^4.0.0"
+    "vinyl-fs": "^4.0.1"
   },
   "devDependencies": {
     "eslint": "^7.0.0",


### PR DESCRIPTION
This upgrades vinyl-fs (which also upgrade vinyl) to avoid the `fs.Stats` deprecation in newer Node.js versions. We did some dark magic to make this go away because the Node TSC are jerks that like to break/churn the ecosystem.