### PR TITLE
fix: Avoid globbing before read stream is opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "glob-watcher": "^6.0.0",
     "gulp-cli": "^3.1.0",
     "undertaker": "^2.0.0",
-    "vinyl-fs": "^4.0.1"
+    "vinyl-fs": "^4.0.2"
   },
   "devDependencies": {
     "eslint": "^7.0.0",


### PR DESCRIPTION
The upgrades vinyl-fs to ensure that the newest glob-stream is pulled in which fixes an issue where globbing could complete before the stream was opened resulting to missed files/incomplete streams/etc.

I think this resolves some issues users were encountering but we'll ask them to test the new version once released before closing them out.

Ref #2807
Ref #2811